### PR TITLE
Refactor: Upgrade to Clap v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Miscellaneous Tasks
 
 - CHANGELOG update
+- Fixed some text output
+
+### Refactor
+
+- Remove lints
 
 ## [0.3.0] - 2022-05-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docmeta"
-version = "0.3.0"
+version = "0.3.2"
 authors = ["Even Solberg"]
 edition = "2021"
 include = ["src/main.rs", "README.md"]
@@ -8,11 +8,11 @@ include = ["src/main.rs", "README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.1.12", features = ["cargo", "color"] }
-env_logger = "0.9.0"
-epub = "1.2.3"
+clap = { version = "4.4.18", features = ["cargo", "color"] }
+env_logger = "0.11.1"
+epub = "2.1.1"
 log = "0.4.16"
-mobi = "0.7.0"
+mobi = "0.8.0"
 pdf = "0.7.2"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,23 +5,18 @@ Show metadata from ePUB, Mobi, and PDF files and rename the files based on the m
 ## Usage
 
 ```console
-USAGE:
-    docmeta [OPTIONS] [filename(S)]...
+Usage: docmeta [OPTIONS] --rename-file <rename-pattern> <filename(s)>...
 
-ARGS:
-    <filename(S)>...    One or more filename(s) to process. Wildcards and multiple_occurrences
-                        filenames (e.g. 2019*.pdf 2020*.pdf) are supported.
+Arguments:
+  <filename(s)>...  One or more filename(s) to process. Wildcards and multiple_occurrences filenames (e.g. 2019*.pdf 2020*.pdf) are supported.
 
-OPTIONS:
-    -h, --help                        Print help information
-    -n, --rename-filename <rename>    Rename filenames based on the provided pattern as they are
-                                      processed.
-    -o, --detail-off                  Don't export detailed information about each filename
-                                      processed.
-    -p, --print-summary               Print summary detail for each session processed.
-    -q, --quiet                       Don't produce any output except errors while working.
-    -r, --dry-run                     Performs a dry-run without executing any actual changes.
-    -V, --version                     Print version information
+Options:
+  -q, --quiet                         Don't produce any output except errors while working.
+  -o, --detail-off                    Don't export detailed information about each filename processed.
+  -r, --dry-run                       Performs a dry-run without executing any actual changes.
+  -n, --rename-file <rename-pattern>  Change filenames based on the provided pattern as they are processed.
+  -h, --help                          Print help (see more with '--help')
+  -V, --version                       Print version
 ```
 
 The `-r`/`--dry-run`, `-o`/`--detail-off`,  and `-q`/`--quiet` options are only relevant when performing renames.
@@ -31,7 +26,7 @@ The `-r`/`--dry-run`, `-o`/`--detail-off`,  and `-q`/`--quiet` options are only 
 | Pattern | Description |
 |:---:| ---|
 | `%t` | Title |
-| `%a` | Author | 
+| `%a` | Author |
 | `%p` | Publisher |
 | `%i` | Identifier (typically ISBN Number) |
 | `%y` | Year |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,62 @@
+//! Contains a single function to build the CLI
+use clap::{Arg, ArgAction, Command};
+
+/// Builds the CLI so the main file doesn't get cluttered.
+pub fn build() -> Command {
+    Command::new(clap::crate_name!())
+        .about(clap::crate_description!())
+        .version(clap::crate_version!())
+        // .author(clap::crate_authors!("\n"))
+        .long_about("This program display eBook metadata and rename files based on this metadata.")
+        .arg(
+            Arg::new("read")
+                .value_name("filename(s)")
+                .help("One or more filename(s) to process. Wildcards and multiple_occurrences filenames (e.g. 2019*.pdf 2020*.pdf) are supported.")
+                .num_args(1..)
+                .required(true)
+                .action(ArgAction::Append),
+        )
+        .arg( // Hidden debug parameter
+            Arg::new("debug")
+                .short('d')
+                .long("debug")
+                .help("Output debug information as we go. Supply it twice for trace-level logs.")
+                .hide(true)
+                .num_args(0)
+                .action(ArgAction::Count)
+        )
+        .arg( // Don't print any information
+            Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .help("Don't produce any output except errors while working.")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+        )
+        .arg( // Don't export detail information
+            Arg::new("detail-off")
+                .short('o')
+                .long("detail-off")
+                .help("Don't export detailed information about each filename processed.")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+        )
+        .arg( // Don't export detail information
+            Arg::new("dry-run")
+                .short('r')
+                .long("dry-run")
+                .help("Performs a dry-run without executing any actual changes.")
+                .num_args(0)
+                .action(ArgAction::SetTrue)
+        )
+        .arg( // Rename filenames
+            Arg::new("rename-pattern")
+                .short('n')
+                .long("rename-file")
+                .help("Change filenames based on the provided pattern as they are processed.")
+                .num_args(1)
+                .action(ArgAction::Set)
+                .required(true)
+                .hide(false),
+        )
+}


### PR DESCRIPTION
- Update some option names and descriptions.
- Remove print-detail option as it didn't do anything.
- Clean up some lints.