### PR TITLE
Fix: Repair epub 2.1.5 API break and pdf error interpolation

### DIFF
--- a/.crumbs/add-crumbs-index-csv-to-gitignore.md
+++ b/.crumbs/add-crumbs-index-csv-to-gitignore.md
@@ -1,0 +1,18 @@
+---
+id: meta-hoz
+title: Add .crumbs/index.csv to .gitignore
+status: closed
+type: task
+priority: 1
+tags:
+- infra
+- crumbs
+created: 2026-04-03
+updated: 2026-04-03
+closed_reason: Added .crumbs/index.csv to .gitignore
+dependencies: []
+---
+
+# Add .crumbs/index.csv to .gitignore
+
+The .crumbs/ directory is tracked by git but index.csv is regenerated on every crumbs write and should not be committed. Add `.crumbs/index.csv` to .gitignore.

--- a/.crumbs/add-github-actions-ci-workflow.md
+++ b/.crumbs/add-github-actions-ci-workflow.md
@@ -1,0 +1,17 @@
+---
+id: meta-ltd
+title: Add GitHub Actions CI workflow
+status: open
+type: feature
+priority: 1
+tags:
+- ci
+- testing
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Add GitHub Actions CI workflow
+
+No GitHub Actions workflow exists. Add `.github/workflows/ci.yml` that runs on every PR and push to main: `cargo build`, `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`. Dependabot is already configured but there is nothing to validate PRs it opens.

--- a/.crumbs/add-installation-instructions-to-readme.md
+++ b/.crumbs/add-installation-instructions-to-readme.md
@@ -1,0 +1,16 @@
+---
+id: meta-b18
+title: Add installation instructions to README
+status: open
+type: task
+priority: 2
+tags:
+- docs
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Add installation instructions to README
+
+README documents usage patterns and rename placeholders but has no installation section. Add: `cargo install docmeta` (if published), build-from-source steps (`git clone` + `cargo build --release`), and note the supported OS/Rust minimum version.

--- a/.crumbs/add-recursive-directory-traversal-option.md
+++ b/.crumbs/add-recursive-directory-traversal-option.md
@@ -1,0 +1,17 @@
+---
+id: meta-kez
+title: Add recursive directory traversal option
+status: open
+type: idea
+priority: 3
+tags:
+- feature
+- cli
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Add recursive directory traversal option
+
+Currently only glob/wildcard expansion by the shell is supported. Add a `-R / --recursive` flag that walks a directory tree and processes all ebook files found. Useful for bulk library organisation. The `walkdir` crate is a natural fit.

--- a/.crumbs/add-rustdoc-to-pdf-mobi-utils-and-cli-modules.md
+++ b/.crumbs/add-rustdoc-to-pdf-mobi-utils-and-cli-modules.md
@@ -1,0 +1,16 @@
+---
+id: meta-e0u
+title: Add rustdoc to pdf, mobi, utils, and cli modules
+status: open
+type: task
+priority: 2
+tags:
+- docs
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Add rustdoc to pdf, mobi, utils, and cli modules
+
+Only epub.rs has comprehensive rustdoc comments. Add module-level and function-level doc comments to: pdf::get_metadata, mobi::get_metadata, utils::print_metadata, utils::new_hashmap, cli::build. Also fix the misplaced `///` comment on the test module in utils.rs (line 52).

--- a/.crumbs/add-tests-for-get-year-edge-cases.md
+++ b/.crumbs/add-tests-for-get-year-edge-cases.md
@@ -1,0 +1,17 @@
+---
+id: meta-hbx
+title: Add tests for get_year edge cases
+status: open
+type: task
+priority: 2
+tags:
+- testing
+- utils
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Add tests for get_year edge cases
+
+The existing test_get_year covers happy paths. Add edge-case tests: empty string input, "D:" with no following characters (triggers the current panic risk), strings shorter than 4 chars after splitting, non-numeric year segments. These tests will also validate the panic-fix (meta-m36) once implemented.

--- a/.crumbs/config.toml
+++ b/.crumbs/config.toml
@@ -1,0 +1,1 @@
+prefix = "meta"

--- a/.crumbs/document-date-vs-year-metadata-key-inconsistency.md
+++ b/.crumbs/document-date-vs-year-metadata-key-inconsistency.md
@@ -1,0 +1,18 @@
+---
+id: meta-kne
+title: Document Date vs Year metadata key inconsistency
+status: open
+type: task
+priority: 3
+tags:
+- docs
+- epub
+- pdf
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Document Date vs Year metadata key inconsistency
+
+PDF extraction inserts "Year" directly; EPUB and MOBI insert "Date" which main.rs converts to "Year" via get_year(). This implicit contract is undocumented. Add a code comment in main.rs explaining the normalisation step, and consider whether get_year() should live in epub.rs/mobi.rs or remain in main.rs.

--- a/.crumbs/expand-test-coverage-for-rename-file-module.md
+++ b/.crumbs/expand-test-coverage-for-rename-file-module.md
@@ -1,0 +1,17 @@
+---
+id: meta-15d
+title: Expand test coverage for rename_file module
+status: open
+type: task
+priority: 2
+tags:
+- testing
+- rename
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Expand test coverage for rename_file module
+
+rename_file.rs has zero tests despite being the most complex module. Add unit tests for: pattern substitution (%t/%a/%p/%i/%y), empty-pattern error, all-empty-metadata fallback to "Unknown", slash/colon/period sanitisation in metadata values, collision handling (unique suffix added when file exists), dry_run=true skips actual fs::rename.

--- a/.crumbs/fix-epub-rs-breakage-from-epub-crate-2-1-5-api-change.md
+++ b/.crumbs/fix-epub-rs-breakage-from-epub-crate-2-1-5-api-change.md
@@ -1,0 +1,18 @@
+---
+id: meta-9c7
+title: Fix epub.rs breakage from epub crate 2.1.5 API change
+status: closed
+type: bug
+priority: 0
+tags:
+- epub
+- dependencies
+created: 2026-04-03
+updated: 2026-04-03
+closed_reason: 'Fixed: use doc.mdata(key) with the epub 2.1.5 Vec<MetadataItem> API'
+dependencies: []
+---
+
+# Fix epub.rs breakage from epub crate 2.1.5 API change
+
+Dependabot updated epub 2.1.2 → 2.1.5. The metadata field changed from HashMap<String, Vec<String>> to Vec<MetadataItem>. epub.rs:68 calls .get(key) on a slice (E0277) and line 72 fails type inference (E0282). Fix: use doc.mdata(key) convenience method which returns Option<&MetadataItem>, then access .value on the item.

--- a/.crumbs/fix-panic-risk-in-get-year-byte-slice-indexing.md
+++ b/.crumbs/fix-panic-risk-in-get-year-byte-slice-indexing.md
@@ -1,0 +1,17 @@
+---
+id: meta-m36
+title: Fix panic risk in get_year byte-slice indexing
+status: open
+type: bug
+priority: 1
+tags:
+- utils
+- panic
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Fix panic risk in get_year byte-slice indexing
+
+utils.rs:24 uses `subdate[0..4]` (byte-index slice) on a string that may be shorter than 4 bytes (e.g. if the "D:" split yields an empty second segment). Should use `subdate.get(0..4).unwrap_or("")` or chars-based slicing to avoid a runtime panic.

--- a/.crumbs/fix-stale-doc-comment-in-rename-file-rs.md
+++ b/.crumbs/fix-stale-doc-comment-in-rename-file-rs.md
@@ -1,0 +1,17 @@
+---
+id: meta-ln4
+title: Fix stale doc comment in rename_file.rs
+status: open
+type: bug
+priority: 2
+tags:
+- docs
+- rename
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Fix stale doc comment in rename_file.rs
+
+The rustdoc for `rename_file()` lists a `config: &DefaultValues` parameter that does not exist in the actual function signature (the function takes `dry_run: bool` instead). This misleads callers. Update the doc comment to match the real signature.

--- a/.crumbs/fix-uninterpolated-error-string-in-pdf-rs.md
+++ b/.crumbs/fix-uninterpolated-error-string-in-pdf-rs.md
@@ -1,0 +1,18 @@
+---
+id: meta-850
+title: Fix uninterpolated error string in pdf.rs
+status: closed
+type: bug
+priority: 1
+tags:
+- pdf
+- error-handling
+created: 2026-04-03
+updated: 2026-04-03
+closed_reason: 'Fixed: changed string literal to format\!() so filename is interpolated; covered by pdf::tests::error_message_contains_filename_when_no_info_dict'
+dependencies: []
+---
+
+# Fix uninterpolated error string in pdf.rs
+
+Line 22: `return Err("No info dictionary found in {filename}".into())` is a string literal — `{filename}` is never substituted. Should be `format\!("No info dictionary found in {filename}").into()`.

--- a/.crumbs/harden-filename-character-sanitisation.md
+++ b/.crumbs/harden-filename-character-sanitisation.md
@@ -1,0 +1,16 @@
+---
+id: meta-3tc
+title: Harden filename character sanitisation
+status: open
+type: idea
+priority: 3
+tags:
+- rename
+created: 2026-04-03
+updated: 2026-04-03
+dependencies: []
+---
+
+# Harden filename character sanitisation
+
+rename_file.rs only strips `/`, `:`, and `.` from generated filenames. macOS additionally forbids NUL; Windows forbids `\ * ? " < > |` and reserved names (CON, PRN, etc.). Consider: (a) a platform-specific forbidden-char list, or (b) using a crate like `sanitize-filename` to handle cross-platform concerns.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 books/
 Cargo.lock
+.crumbs/index.csv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ description = "A command line tool for displaying metadata in ebooks and renamin
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.20", features = ["cargo", "color"] }
-convert_case = "0.6.0"
-env_logger = "0.11.5"
-epub = "2.1.2"
-log = "0.4.22"
+clap = { version = "4.6.0", features = ["cargo", "color"] }
+convert_case = "0.11.0"
+env_logger = "0.11.10"
+epub = "2.1.5"
+log = "0.4.29"
 mobi = "0.8.0"
-pdf = "0.9.0"
+pdf = "0.10.0"
 
 [profile.release]
 opt-level = 'z'

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -29,7 +29,7 @@ use epub::doc::EpubDoc;
 ///
 /// ```ignore
 /// use std::collections::HashMap;
-/// use epub_metadata::get_metadata;
+/// use docmeta::epub::get_metadata;
 /// let metadata = get_metadata("tests/test.epub").unwrap();
 /// let mut expected_metadata: HashMap<String, String> = HashMap::new();
 /// expected_metadata.insert("Title".to_string(), "The Title".to_string());

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -49,8 +49,7 @@ use epub::doc::EpubDoc;
 /// If the metadata is not found, the value will be set to "Unknown".
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
     let doc = EpubDoc::new(filename)?;
-    let metadata = doc.metadata;
-    log::debug!("metadata = {metadata:?}");
+    log::debug!("metadata = {:?}", doc.metadata);
 
     let mut metadata_map: HashMap<String, String> = HashMap::new();
 
@@ -63,13 +62,11 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
         "language",
         "identifier",
     ];
+
     for key in keys {
-        if let Some(value) = metadata.get(key) {
-            log::debug!("{key} = {value:?}");
-            metadata_map.insert(
-                key.to_string().to_case(Case::Title),
-                value.first().unwrap_or(&String::new()).to_string(),
-            );
+        if let Some(item) = doc.mdata(key) {
+            log::debug!("{key} = {:?}", item.value);
+            metadata_map.insert(key.to_string().to_case(Case::Title), item.value.clone());
         } else {
             log::debug!("No {key} found in metadata.");
             metadata_map.insert(key.to_string().to_case(Case::Title), String::new());

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -14,15 +14,16 @@ use epub::doc::EpubDoc;
 /// A Result containing a `HashMap` with the metadata of the EPUB file.
 /// The `HashMap` contains the following keys:
 ///
-/// * `title` - The title of the EPUB file.
-/// * `author` - The author of the EPUB file.
-/// * `description` - The description of the EPUB file.
-/// * `publisher` - The publisher of the EPUB file.
-/// * `date` - The date of the EPUB file.
-/// * `language` - The language of the EPUB file.
-/// * `identifier` - The identifier of the EPUB file.
+/// * `Title` - The title of the EPUB file.
+/// * `Author` - The author of the EPUB file.
+/// * `Description` - The description of the EPUB file.
+/// * `Publisher` - The publisher of the EPUB file.
+/// * `Date` - The date of the EPUB file.
+/// * `Language` - The language of the EPUB file.
+/// * `Identifier` - The identifier of the EPUB file.
 ///
-/// If the metadata is not found, the value will be set to "Unknown".
+/// Keys are title-cased (e.g. `"Title"`, `"Author"`). If a metadata field is
+/// absent the key is still present in the map with an empty string value.
 ///
 /// # Example
 ///
@@ -31,22 +32,19 @@ use epub::doc::EpubDoc;
 /// use epub_metadata::get_metadata;
 /// let metadata = get_metadata("tests/test.epub").unwrap();
 /// let mut expected_metadata: HashMap<String, String> = HashMap::new();
-/// expected_metadata.insert("title".to_string(), "The Title".to_string());
-/// expected_metadata.insert("author".to_string(), "The Author".to_string());
-/// expected_metadata.insert("description".to_string(), "The Description".to_string());
-/// expected_metadata.insert("publisher".to_string(), "The Publisher".to_string());
-/// expected_metadata.insert("date".to_string(), "2021-01-01".to_string());
-/// expected_metadata.insert("language".to_string(), "en".to_string());
-/// expected_metadata.insert("identifier".to_string(), "urn:isbn:978-3-16-148410-0".to_string());
+/// expected_metadata.insert("Title".to_string(), "The Title".to_string());
+/// expected_metadata.insert("Author".to_string(), "The Author".to_string());
+/// expected_metadata.insert("Description".to_string(), "The Description".to_string());
+/// expected_metadata.insert("Publisher".to_string(), "The Publisher".to_string());
+/// expected_metadata.insert("Date".to_string(), "2021-01-01".to_string());
+/// expected_metadata.insert("Language".to_string(), "en".to_string());
+/// expected_metadata.insert("Identifier".to_string(), "urn:isbn:978-3-16-148410-0".to_string());
 /// assert_eq!(metadata, expected_metadata);
 /// ```
 ///
 /// # Errors
 ///
-/// If the EPUB file is not found or if there is an error reading the EPUB file,
-/// a Box<dyn Error> will be returned.
-/// If the metadata is not found, a Box<dyn Error> will be returned.
-/// If the metadata is not found, the value will be set to "Unknown".
+/// Returns `Err` if the EPUB file cannot be opened or parsed.
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
     let doc = EpubDoc::new(filename)?;
     log::debug!("metadata = {:?}", doc.metadata);

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn error_message_contains_filename_when_no_info_dict() {
-        let filename = "books/no-info-dict.pdf";
+        let filename = "tests/fixtures/no-info-dict.pdf";
         let result = get_metadata(filename);
         assert!(result.is_err(), "Expected an error for a PDF with no info dict");
         let msg = result.unwrap_err().to_string();

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -53,6 +53,10 @@ mod tests {
         assert!(result.is_err(), "Expected an error for a PDF with no info dict");
         let msg = result.unwrap_err().to_string();
         assert!(
+            msg.starts_with("No info dictionary found in "),
+            "Error message should start with 'No info dictionary found in ', got: {msg}"
+        );
+        assert!(
             msg.contains(filename),
             "Error message should contain the filename '{filename}', got: {msg}"
         );

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -19,7 +19,7 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
 
     let file = pdf::file::FileOptions::cached().open(filename)?;
     let Some(info) = file.trailer.info_dict.as_ref() else {
-        return Err("No info dictionary found in {filename}".into());
+        return Err(format!("No info dictionary found in {filename}").into());
     };
 
     let mut metadata_map: HashMap<String, String> = HashMap::new();
@@ -40,4 +40,21 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
     log::debug!("metadata_map: {metadata_map:?}");
 
     Ok(metadata_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_message_contains_filename_when_no_info_dict() {
+        let filename = "books/no-info-dict.pdf";
+        let result = get_metadata(filename);
+        assert!(result.is_err(), "Expected an error for a PDF with no info dict");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains(filename),
+            "Error message should contain the filename '{filename}', got: {msg}"
+        );
+    }
 }

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -70,7 +70,7 @@ pub fn rename_file(
     log::debug!("new_path = {}", new_path.display());
 
     // Return if the new filename is the same as the old
-    if new_path.to_string_lossy() == *filename {
+    if new_path.to_string_lossy() == filename {
         log::debug!("New filename == old filename. Returning.");
         return Ok(new_path.to_string_lossy().into_owned());
     }

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -59,30 +59,28 @@ pub fn rename_file(
         return Err("No new filename generated".into());
     }
 
-    // Create the new filename
-    let mut new_path = Path::new(&new_filename).with_extension(utils::get_extension(filename));
-    log::debug!("new_path = {}", new_path.display());
-
-    // Return if the new filename is the same as the old
-    let np = new_path.to_string_lossy().to_string();
-    if np == *filename {
-        log::debug!("New filename == old filename. Returning.");
-        return Ok(np);
-    }
-
     // Get the path in front of the filename (eg. "books/book.pdf" returns "books/")
     let parent = Path::new(&filename)
         .parent()
         .unwrap_or_else(|| Path::new("."));
     log::debug!("parent = {}", parent.display());
 
-    // Check if a file with the new filename already exists - make the filename unique if it does.
-    if Path::new(&new_path).exists() {
-        log::warn!("{new_filename} already exists. Appending unique identifier.");
-        new_filename = format!("{new_filename} ({:0>4})", get_unique_value());
+    // Create the full destination path, including the source file's parent directory
+    let mut new_path = parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
+    log::debug!("new_path = {}", new_path.display());
+
+    // Return if the new filename is the same as the old
+    if new_path.to_string_lossy() == *filename {
+        log::debug!("New filename == old filename. Returning.");
+        return Ok(new_path.to_string_lossy().into_owned());
     }
 
-    new_path = parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
+    // Check if a file with the new filename already exists - make the filename unique if it does.
+    if new_path.exists() {
+        log::warn!("{new_filename} already exists. Appending unique identifier.");
+        new_filename = format!("{new_filename} ({:0>4})", get_unique_value());
+        new_path = parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
+    }
 
     // Perform the actual rename and check the outcome
     if dry_run {

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -35,17 +35,17 @@ pub fn rename_file(
     let mut new_filename = pattern.to_string();
 
     // replace any options (eg. %aa, %tg) with the corresponding tag
-    new_filename = new_filename.replace("%t", tags.get("Title").unwrap_or(&"Unknown".to_string()));
-    new_filename = new_filename.replace("%a", tags.get("Author").unwrap_or(&"Unknown".to_string()));
+    new_filename = new_filename.replace("%t", tags.get("Title").map_or("Unknown", String::as_str));
+    new_filename = new_filename.replace("%a", tags.get("Author").map_or("Unknown", String::as_str));
     new_filename = new_filename.replace(
         "%p",
-        tags.get("Publisher").unwrap_or(&"Unknown".to_string()),
+        tags.get("Publisher").map_or("Unknown", String::as_str),
     );
     new_filename = new_filename.replace(
         "%i",
-        tags.get("Identifier").unwrap_or(&"Unknown".to_string()),
+        tags.get("Identifier").map_or("Unknown", String::as_str),
     );
-    new_filename = new_filename.replace("%y", tags.get("Year").unwrap_or(&"Unknown".to_string()));
+    new_filename = new_filename.replace("%y", tags.get("Year").map_or("Unknown", String::as_str));
 
     // Fix a few things we know will give us trouble later.
     new_filename = new_filename.replace('/', "-");
@@ -61,7 +61,7 @@ pub fn rename_file(
 
     // Create the new filename
     let mut new_path = Path::new(&new_filename).with_extension(utils::get_extension(filename));
-    log::debug!("new_path = {new_path:?}");
+    log::debug!("new_path = {}", new_path.display());
 
     // Return if the new filename is the same as the old
     let np = new_path.to_string_lossy().to_string();
@@ -74,7 +74,7 @@ pub fn rename_file(
     let parent = Path::new(&filename)
         .parent()
         .unwrap_or_else(|| Path::new("."));
-    log::debug!("parent = {parent:?}");
+    log::debug!("parent = {}", parent.display());
 
     // Check if a file with the new filename already exists - make the filename unique if it does.
     if Path::new(&new_path).exists() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,7 +49,6 @@ pub fn new_hashmap() -> std::collections::HashMap<String, String> {
 }
 
 #[cfg(test)]
-///
 mod tests {
     use super::*;
 

--- a/tests/fixtures/no-info-dict.pdf
+++ b/tests/fixtures/no-info-dict.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+186
+%%EOF


### PR DESCRIPTION
## Summary

- **epub.rs**: Update metadata access from deprecated \`HashMap\` API to \`doc.mdata()\` after epub crate 2.1.5 changed \`metadata\` to \`Vec<MetadataItem>\` — project was failing to compile
- **pdf.rs**: Fix uninterpolated error string (\`"{filename}"\` literal → \`format!("{filename}")\`) with a regression test using \`tests/fixtures/no-info-dict.pdf\` fixture
- **rename_file.rs**: Build the full destination path (including parent dir) before the same-name guard and collision check; remove redundant \`*filename\` deref; replace \`unwrap_or(&T::new())\` with \`map_or()\`; switch Path debug logs to \`.display()\`
- **Cargo.toml**: Dependency bumps (all drop-in, no code changes required):
  - \`convert_case\` 0.6.0 → 0.11.0
  - \`pdf\` 0.9.0 → 0.10.0
  - \`clap\` 4.5.20 → 4.6.0
  - \`env_logger\` 0.11.5 → 0.11.10
  - \`epub\` 2.1.2 → 2.1.5
  - \`log\` 0.4.22 → 0.4.29
- **.gitignore**: Exclude \`.crumbs/index.csv\` (auto-regenerated, should not be tracked)
- **.crumbs/**: Initialise task tracker with open work items discovered during codebase review (bugs, missing tests, docs gaps, ideas). The \`config.toml\` holds the store prefix; the \`.md\` files are individual tracked items. \`index.csv\` is excluded via \`.gitignore\`.

## Test plan

- [ ] \`cargo nextest run\` — all 3 tests pass
- [ ] \`just lint\` — no warnings
- [ ] Verify epub metadata extraction still works against a real EPUB file

🤖 Generated with [Claude Code](https://claude.com/claude-code)