### PR TITLE
Docs: Fix stale doc comment in rename_file

### DIFF
--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -11,11 +11,11 @@ use std::{
 /// **Parameters:**
 ///
 /// - `filename: &str` -- the name of the file to be renamed
-/// - `tags: &HashMap<String, String>` -- The various tag values (ie. Album Artist, Genre, etc.)
+/// - `tags: &HashMap<String, String>` -- The metadata values (e.g. Title, Author, Year, Publisher).
 /// - `pattern: &str` -- the tag pattern for the new filename. This has been validated to be OK by the CLI.
-/// - `config: &DefaultValues` -- The tags that have been set, and any config settings such as dry-run.
+/// - `dry_run: bool` -- if `true`, log what would happen but do not rename the file.
 ///
-/// Note that you'll need to populate the tags struct _before_ using this function. This is to avoid having to re-open the file and re-read the data.
+/// Note that you'll need to populate the tags map _before_ using this function. This is to avoid having to re-open the file and re-read the data.
 ///
 /// **Returns**
 ///


### PR DESCRIPTION
## Summary
- Replace nonexistent `config: &DefaultValues` parameter with actual `dry_run: bool`
- Update tag value examples from music metadata (Album Artist, Genre) to ebook metadata (Title, Author, Year, Publisher)
- Change "tags struct" → "tags map" to match the `HashMap<String, String>` type

Closes meta-ln4.

## Test plan
- [x] `just lint` passes with zero warnings
- [x] `cargo nextest run` — all 4 tests pass
- [x] Doc comment matches actual function signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)