### PR TITLE
Fix: Correct get_unique_value doc comment and add test

### DIFF
--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -105,11 +105,9 @@ pub fn rename_file(
     Ok(result)
 }
 
-/// Returns a unique numeric identifier derived from the microsecond component of the current
-/// duration since `UNIX_EPOCH`, modulated to at most 7 digits (`0–9_999_999`).
-/// This is used to ensure uniqueness of file names.
-/// This can be changed to something else later without impacting the main application.
-/// For example, one could switch to a random number generator or something.
+/// Returns a unique numeric identifier (range `0–9_999_999`) derived from the microsecond
+/// component of the current duration since `UNIX_EPOCH`. Used to de-collide file names.
+/// The implementation can be swapped (e.g. for an RNG) without affecting callers.
 fn get_unique_value() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -125,7 +123,8 @@ mod tests {
     #[test]
     fn unique_value_is_within_seven_digits() {
         for _ in 0..100 {
-            assert!(get_unique_value() < 10_000_000, "get_unique_value() must be < 10_000_000");
+            let val = get_unique_value();
+            assert!(val < 10_000_000, "expected < 10_000_000, got {val}");
         }
     }
 }

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -105,7 +105,8 @@ pub fn rename_file(
     Ok(result)
 }
 
-/// Gets the microsecond part of the current duration since `UNIX_EPOCH` and modulate to a 4-digit number.
+/// Returns a unique numeric identifier derived from the microsecond component of the current
+/// duration since `UNIX_EPOCH`, modulated to at most 7 digits (`0–9_999_999`).
 /// This is used to ensure uniqueness of file names.
 /// This can be changed to something else later without impacting the main application.
 /// For example, one could switch to a random number generator or something.
@@ -115,4 +116,16 @@ fn get_unique_value() -> u128 {
         .expect("Time went backwards. You probably have bigger things to worry about.")
         .as_micros()
         % 10_000_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_value_is_within_seven_digits() {
+        for _ in 0..100 {
+            assert!(get_unique_value() < 10_000_000, "get_unique_value() must be < 10_000_000");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- The doc comment claimed "4-digit number" but the modulus `% 10_000_000` produces up to 7 digits
- `% 10_000` would cycle every 10 ms — too short for fast batch renames with microsecond resolution
- Fix: update the doc comment to say "range `0–9_999_999`"; keep the modulus as-is
- Add `#[cfg(test)]` block with a test that enforces the documented range

Closes meta-uyh.

## Test plan
- [x] `just lint` — zero warnings
- [x] `cargo nextest run` — all 5 tests pass
- [x] Test asserts `get_unique_value() < 10_000_000` with diagnostic value in failure message

🤖 Generated with [Claude Code](https://claude.com/claude-code)