### PR TITLE
Test: Add test coverage for rename_file module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = 'abort'
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -119,6 +119,14 @@ fn get_unique_value() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    fn tags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()
+    }
+
+    // ── get_unique_value ────────────────────────────────────────────────────
 
     #[test]
     fn unique_value_is_within_seven_digits() {
@@ -126,5 +134,124 @@ mod tests {
             let val = get_unique_value();
             assert!(val < 10_000_000, "expected < 10_000_000, got {val}");
         }
+    }
+
+    // ── error paths ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_pattern_returns_error() {
+        let result = rename_file("some_file.epub", &tags(&[]), "", false);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "No rename pattern provided");
+    }
+
+    #[test]
+    fn pattern_that_sanitises_to_empty_returns_error() {
+        // Pattern "." becomes "" after the '.' sanitisation step
+        let result = rename_file("some_file.epub", &tags(&[]), ".", false);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "No new filename generated");
+    }
+
+    // ── tag substitution ────────────────────────────────────────────────────
+
+    #[test]
+    fn all_placeholders_are_substituted() {
+        let t = tags(&[
+            ("Title", "My Book"),
+            ("Author", "Jane Doe"),
+            ("Publisher", "Acme"),
+            ("Identifier", "978-0-00-000000-0"),
+            ("Year", "2024"),
+        ]);
+        // dry_run so no actual file access is needed for the substitution check
+        let result = rename_file("placeholder.epub", &t, "%a - %t (%y) [%p] %i", true);
+        // The result path ends with the substituted stem + original extension
+        let path = result.expect("should succeed");
+        assert!(path.contains("Jane Doe"), "author missing: {path}");
+        assert!(path.contains("My Book"), "title missing: {path}");
+        assert!(path.contains("2024"), "year missing: {path}");
+        assert!(path.contains("Acme"), "publisher missing: {path}");
+        assert!(path.contains("978-0-00-000000-0"), "identifier missing: {path}");
+    }
+
+    #[test]
+    fn missing_tags_fall_back_to_unknown() {
+        let result = rename_file("placeholder.epub", &tags(&[]), "%t - %a", true);
+        let path = result.expect("should succeed");
+        assert!(path.contains("Unknown - Unknown"), "expected 'Unknown - Unknown' in {path}");
+    }
+
+    // ── character sanitisation ───────────────────────────────────────────────
+
+    #[test]
+    fn slash_in_tag_is_replaced_with_dash() {
+        let t = tags(&[("Title", "A/B")]);
+        let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
+        assert!(result.contains("A-B"), "slash not sanitised: {result}");
+    }
+
+    #[test]
+    fn colon_in_tag_is_replaced_with_space_dash() {
+        let t = tags(&[("Title", "Volume: One")]);
+        let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
+        assert!(result.contains("Volume - One"), "colon not sanitised: {result}");
+    }
+
+    #[test]
+    fn dot_in_tag_is_removed() {
+        let t = tags(&[("Title", "Mr. Smith")]);
+        let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
+        assert!(result.contains("Mr Smith"), "dot not removed: {result}");
+    }
+
+    // ── dry run ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_does_not_rename_file() {
+        let src = NamedTempFile::new().expect("temp file");
+        let src_path = src.path().to_string_lossy().to_string();
+        let t = tags(&[("Title", "NewName")]);
+
+        let result = rename_file(&src_path, &t, "%t", true).expect("ok");
+
+        // Source still exists
+        assert!(fs::metadata(&src_path).is_ok(), "source was deleted in dry-run");
+        // Destination (result path) does not exist
+        assert!(!fs::metadata(&result).is_ok() || result == src_path,
+            "destination was created in dry-run");
+    }
+
+    // ── actual rename ────────────────────────────────────────────────────────
+
+    #[test]
+    fn rename_moves_file_to_new_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src_path = dir.path().join("source.epub");
+        fs::write(&src_path, b"").expect("create src");
+        let src_str = src_path.to_string_lossy().to_string();
+
+        let t = tags(&[("Title", "RenamedFile")]);
+        let result = rename_file(&src_str, &t, "%t", false).expect("rename should succeed");
+
+        assert!(!fs::metadata(&src_str).is_ok(), "source still exists after rename");
+        assert!(fs::metadata(&result).is_ok(), "destination does not exist after rename");
+    }
+
+    // ── same-filename guard ──────────────────────────────────────────────────
+
+    #[test]
+    fn same_filename_returns_ok_without_moving() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let src_path = dir.path().join("mybook.epub");
+        fs::write(&src_path, b"").expect("create src");
+        let src_str = src_path.to_string_lossy().to_string();
+
+        // Pattern "%t" with Title="mybook" produces "mybook.epub" — same as source
+        let t = tags(&[("Title", "mybook")]);
+        let result = rename_file(&src_str, &t, "%t", false).expect("ok");
+
+        assert_eq!(result, src_str, "should return the same path unchanged");
+        assert!(fs::metadata(&src_str).is_ok(), "file should still exist");
     }
 }

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -218,8 +218,7 @@ mod tests {
         // Source still exists
         assert!(fs::metadata(&src_path).is_ok(), "source was deleted in dry-run");
         // Destination (result path) does not exist
-        assert!(!fs::metadata(&result).is_ok() || result == src_path,
-            "destination was created in dry-run");
+        assert!(fs::metadata(&result).is_err(), "destination was created in dry-run");
     }
 
     // ── actual rename ────────────────────────────────────────────────────────
@@ -234,7 +233,7 @@ mod tests {
         let t = tags(&[("Title", "RenamedFile")]);
         let result = rename_file(&src_str, &t, "%t", false).expect("rename should succeed");
 
-        assert!(!fs::metadata(&src_str).is_ok(), "source still exists after rename");
+        assert!(fs::metadata(&src_str).is_err(), "source still exists after rename");
         assert!(fs::metadata(&result).is_ok(), "destination does not exist after rename");
     }
 


### PR DESCRIPTION
## Summary
- 10 new tests covering all code paths in `rename_file()`: both error exits, all 5 tag substitutions (`%t %a %p %i %y`), all 3 character sanitisations (`/` `:` `.`), dry-run, actual rename, and same-filename guard
- Adds `tempfile` as a dev-dependency for real filesystem tests (no mocks)

Closes meta-15d.

## Test plan
- [x] `just lint` — zero warnings
- [x] `cargo nextest run` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)