### PR TITLE
Docs: Add rustdoc to pdf, mobi, utils, and cli modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use clap::{Arg, ArgAction, Command};
 /// | `--quiet` | `-q` | Suppress all output except errors |
 /// | `--detail-off` | `-o` | Skip per-file metadata output (useful when renaming) |
 /// | `--dry-run` | `-r` | Show what would happen without making changes |
-/// | `--rename-file` | `-n` | Rename each file according to the given pattern |
+/// | `--rename-file <pattern>` | `-n` | Rename each file using `<pattern>` as the template |
 pub fn build() -> Command {
     Command::new(clap::crate_name!())
         .about(clap::crate_description!())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,18 @@
 //! Contains a single function to build the CLI
 use clap::{Arg, ArgAction, Command};
 
-/// Builds the CLI so the main file doesn't get cluttered.
+/// Build and return the top-level [`Command`] for the application.
+///
+/// Keeps argument definitions out of `main.rs`. The returned command accepts:
+///
+/// | Flag / Argument | Short | Description |
+/// |-----------------|-------|-------------|
+/// | `<filename(s)>` | — | One or more files to process (required) |
+/// | `--debug` | `-d` | Enable debug logging; repeat for trace level (hidden) |
+/// | `--quiet` | `-q` | Suppress all output except errors |
+/// | `--detail-off` | `-o` | Skip per-file metadata output (useful when renaming) |
+/// | `--dry-run` | `-r` | Show what would happen without making changes |
+/// | `--rename-file` | `-n` | Rename each file according to the given pattern |
 pub fn build() -> Command {
     Command::new(clap::crate_name!())
         .about(clap::crate_description!())

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -2,6 +2,28 @@ use mobi::Mobi;
 
 use std::{collections::HashMap, error::Error};
 
+/// Read metadata from a MOBI file and return it as a [`HashMap`].
+///
+/// # Arguments
+///
+/// * `filename` - Path to the MOBI file to read.
+///
+/// # Returns
+///
+/// A [`HashMap`] containing the following keys (all `String` values):
+///
+/// | Key | Source field |
+/// |-----|-------------|
+/// | `"Title"` | Book title |
+/// | `"Author"` | Author name, or empty string if absent |
+/// | `"Description"` | Book description, or empty string if absent |
+/// | `"Publisher"` | Publisher name, or empty string if absent |
+/// | `"Identifier"` | ISBN, or empty string if absent |
+/// | `"Date"` | Publish date string, or empty string if absent |
+///
+/// # Errors
+///
+/// Returns `Err` if the file cannot be opened or parsed as a MOBI document.
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
     let mobi_file = Mobi::from_path(filename)?;
     log::debug!("metadata = {:?}", mobi_file.metadata);

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -1,7 +1,10 @@
 use pdf::primitive::PdfString;
 use std::{collections::HashMap, error::Error};
 
-/// Get the metadata from a PDF file and insert it into the provided hashmap.
+/// Extract a named field from a PDF info dictionary into `$mm`.
+///
+/// Falls back to `"Unknown"` when the field is absent or cannot be converted to a
+/// UTF-8 string, and strips any embedded double-quote characters from the value.
 macro_rules! get_field {
     ($id:ident, $field:ident, $mm:ident, $key:expr) => {
         let mut $field = <Option<PdfString> as Clone>::clone(&$id.$field)
@@ -13,7 +16,32 @@ macro_rules! get_field {
     };
 }
 
-/// get the metadata from a PDF file
+/// Read metadata from a PDF file and return it as a [`HashMap`].
+///
+/// # Arguments
+///
+/// * `filename` - Path to the PDF file to read.
+///
+/// # Returns
+///
+/// A [`HashMap`] containing the following keys (all `String` values):
+///
+/// | Key | Source field |
+/// |-----|-------------|
+/// | `"Author"` | `info.author` |
+/// | `"Title"` | `info.title` |
+/// | `"Subject"` | `info.subject` |
+/// | `"Keywords"` | `info.keywords` |
+/// | `"Creator"` | `info.creator` |
+/// | `"Producer"` | `info.producer` |
+/// | `"Year"` | `info.creation_date.year` |
+///
+/// Fields absent from the PDF info dictionary are inserted with the value `"Unknown"`,
+/// except `"Year"` which is inserted as an empty string when the creation date is missing.
+///
+/// # Errors
+///
+/// Returns `Err` if the file cannot be opened or if the PDF has no info dictionary.
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
     log::debug!("Opening file: {filename}");
 

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -41,7 +41,10 @@ macro_rules! get_field {
 ///
 /// # Errors
 ///
-/// Returns `Err` if the file cannot be opened or if the PDF has no info dictionary.
+/// Returns `Err` in two distinct cases:
+/// - The `pdf` crate cannot open or parse the file (corrupt data, unsupported version,
+///   permission denied, etc.) — the underlying crate error is propagated.
+/// - The PDF contains no info dictionary — the error message includes `filename`.
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
     log::debug!("Opening file: {filename}");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,15 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
-/// Get the extension part of the filename and return it as a string
+/// Return the lowercase file extension of `filename`, or an empty string if there is none.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(get_extension("book.epub"), "epub");
+/// assert_eq!(get_extension("archive.tar.gz"), "gz");
+/// assert_eq!(get_extension("README"), "");
+/// ```
 pub fn get_extension(filename: &str) -> String {
     Path::new(&filename)
         .extension()
@@ -12,7 +20,26 @@ pub fn get_extension(filename: &str) -> String {
         .to_string()
 }
 
-/// Get the year from a date string
+/// Extract the four-digit year from a date string.
+///
+/// Handles three common formats:
+///
+/// - A bare four-digit year (`"2024"`) is returned as-is.
+/// - A PDF date string prefixed with `"D:"` (e.g. `"D:20240101120000+00'00'"`) — the four
+///   digits immediately after the prefix are returned.
+/// - An ISO 8601 / hyphen-separated date (e.g. `"2024-01-01"`) — the part before the first
+///   hyphen is returned.
+///
+/// Returns an empty string when the year cannot be determined.
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(get_year("2024-06-15"), "2024");
+/// assert_eq!(get_year("D:20240615120000+00'00'"), "2024");
+/// assert_eq!(get_year("2024"), "2024");
+/// assert_eq!(get_year("D:"), "");
+/// ```
 pub fn get_year(date: &str) -> String {
     // If it's already a year, just return it
     if date.len() == 4 && date.chars().all(char::is_numeric) {
@@ -31,7 +58,9 @@ pub fn get_year(date: &str) -> String {
     year.trim().to_string()
 }
 
-/// Print the metadata
+/// Print each metadata key/value pair to stdout.
+///
+/// Empty values are displayed as `"N/A"` rather than a blank.
 pub fn print_metadata(tags: &std::collections::HashMap<String, String>) {
     for (key, value) in tags {
         if value.is_empty() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,8 @@ pub fn get_extension(filename: &str) -> String {
 /// - An ISO 8601 / hyphen-separated date (e.g. `"2024-01-01"`) — the part before the first
 ///   hyphen is returned.
 ///
-/// Returns an empty string when the year cannot be determined.
+/// Returns an empty string when the year cannot be extracted from a recognised format.
+/// Any string that does not match the above patterns is returned unchanged.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary
- **pdf**: document `get_field!` macro and `get_metadata()` with Arguments, Returns (keyed table), and Errors sections (distinguishing the two error paths)
- **mobi**: document `get_metadata()` with the same structure
- **utils**: expand one-line stubs on `get_extension`, `get_year` (with examples and passthrough behaviour), and `print_metadata`
- **cli**: expand `build()` doc with a flag reference table; mark `--rename-file` as value-taking

Closes meta-e0u.

## Test plan
- [x] `just lint` — zero warnings
- [x] `cargo nextest run` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)