### PR TITLE
Feat: Add GitHub Actions CI workflow + bump to v0.3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: >
+          cargo clippy --all-targets
+          -- -D warnings
+          -W clippy::pedantic
+          -W clippy::nursery
+          -W clippy::unwrap_used
+
+      - name: Tests
+        run: cargo nextest run
+
+      - name: Build release
+        run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -34,14 +36,14 @@ jobs:
 
       - name: Clippy
         run: >
-          cargo clippy --all-targets
+          cargo clippy --all-targets --all-features
           -- -D warnings
           -W clippy::pedantic
           -W clippy::nursery
           -W clippy::unwrap_used
 
       - name: Tests
-        run: cargo nextest run
+        run: cargo nextest run --locked
 
       - name: Build release
-        run: cargo build --release
+        run: cargo build --release --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [0.3.6] - 2026-04-04
 
 ### Refactor
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docmeta"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Even Solberg"]
 edition = "2021"
 include = ["src/main.rs", "README.md"]

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -74,7 +74,10 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
     }
 
     // Extract year from the date string and store it alongside
-    let date = metadata_map.get("Date").map_or("", String::as_str).to_owned();
+    let date = metadata_map
+        .get("Date")
+        .map_or("", String::as_str)
+        .to_owned();
     metadata_map.insert("Year".to_string(), utils::get_year(&date));
 
     // return the metadata
@@ -89,6 +92,10 @@ mod tests {
     #[test]
     fn get_metadata_includes_year_key() {
         let map = get_metadata("tests/fixtures/Mastering.epub").expect("should parse");
-        assert_eq!(map.get("Year").map(String::as_str), Some("2019"), "unexpected Year value");
+        assert_eq!(
+            map.get("Year").map(String::as_str),
+            Some("2019"),
+            "unexpected Year value"
+        );
     }
 }

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -54,7 +54,10 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
     );
 
     // Extract year from the date string and store it alongside
-    let date = metadata_map.get("Date").map_or("", String::as_str).to_owned();
+    let date = metadata_map
+        .get("Date")
+        .map_or("", String::as_str)
+        .to_owned();
     metadata_map.insert("Year".to_string(), utils::get_year(&date));
 
     log::debug!("metadata_map = {metadata_map:?}");
@@ -70,6 +73,10 @@ mod tests {
     #[test]
     fn get_metadata_includes_year_key() {
         let map = get_metadata("tests/fixtures/Mastering.mobi").expect("should parse");
-        assert_eq!(map.get("Year").map(String::as_str), Some("2019"), "unexpected Year value");
+        assert_eq!(
+            map.get("Year").map(String::as_str),
+            Some("2019"),
+            "unexpected Year value"
+        );
     }
 }

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -81,7 +81,10 @@ mod tests {
     fn error_message_contains_filename_when_no_info_dict() {
         let filename = "tests/fixtures/no-info-dict.pdf";
         let result = get_metadata(filename);
-        assert!(result.is_err(), "Expected an error for a PDF with no info dict");
+        assert!(
+            result.is_err(),
+            "Expected an error for a PDF with no info dict"
+        );
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.starts_with("No info dictionary found in "),

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -85,7 +85,7 @@ mod tests {
             result.is_err(),
             "Expected an error for a PDF with no info dict"
         );
-        let msg = result.unwrap_err().to_string();
+        let msg = result.expect_err("should fail").to_string();
         assert!(
             msg.starts_with("No info dictionary found in "),
             "Error message should start with 'No info dictionary found in ', got: {msg}"

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -71,7 +71,8 @@ pub fn rename_file(
     log::debug!("parent = {}", parent.display());
 
     // Create the full destination path, including the source file's parent directory
-    let mut new_path = parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
+    let mut new_path =
+        parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
     log::debug!("new_path = {}", new_path.display());
 
     // Return if the new filename is the same as the old
@@ -84,7 +85,8 @@ pub fn rename_file(
     if new_path.exists() {
         log::warn!("{new_filename} already exists. Appending unique identifier.");
         new_filename = format!("{new_filename} ({:0>4})", get_unique_value());
-        new_path = parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
+        new_path =
+            parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
     }
 
     // Perform the actual rename and check the outcome
@@ -128,7 +130,10 @@ mod tests {
     use tempfile::NamedTempFile;
 
     fn tags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        pairs.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
     }
 
     // ── get_unique_value ────────────────────────────────────────────────────
@@ -147,7 +152,10 @@ mod tests {
     fn empty_pattern_returns_error() {
         let result = rename_file("some_file.epub", &tags(&[]), "", false);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "No rename pattern provided");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No rename pattern provided"
+        );
     }
 
     #[test]
@@ -177,14 +185,20 @@ mod tests {
         assert!(path.contains("My Book"), "title missing: {path}");
         assert!(path.contains("2024"), "year missing: {path}");
         assert!(path.contains("Acme"), "publisher missing: {path}");
-        assert!(path.contains("978-0-00-000000-0"), "identifier missing: {path}");
+        assert!(
+            path.contains("978-0-00-000000-0"),
+            "identifier missing: {path}"
+        );
     }
 
     #[test]
     fn missing_tags_fall_back_to_unknown() {
         let result = rename_file("placeholder.epub", &tags(&[]), "%t - %a", true);
         let path = result.expect("should succeed");
-        assert!(path.contains("Unknown - Unknown"), "expected 'Unknown - Unknown' in {path}");
+        assert!(
+            path.contains("Unknown - Unknown"),
+            "expected 'Unknown - Unknown' in {path}"
+        );
     }
 
     // ── character sanitisation ───────────────────────────────────────────────
@@ -200,7 +214,10 @@ mod tests {
     fn colon_in_tag_is_replaced_with_space_dash() {
         let t = tags(&[("Title", "Volume: One")]);
         let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
-        assert!(result.contains("Volume - One"), "colon not sanitised: {result}");
+        assert!(
+            result.contains("Volume - One"),
+            "colon not sanitised: {result}"
+        );
     }
 
     #[test]
@@ -222,7 +239,10 @@ mod tests {
         // * ? " < > | are forbidden on Windows
         let t = tags(&[("Title", "A*B?C\"D<E>F|G")]);
         let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
-        assert!(result.contains("ABCDEFG"), "forbidden chars not removed: {result}");
+        assert!(
+            result.contains("ABCDEFG"),
+            "forbidden chars not removed: {result}"
+        );
     }
 
     #[test]
@@ -238,7 +258,10 @@ mod tests {
         let t = tags(&[("Title", "A\0B")]);
         let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
         assert!(result.contains("AB"), "NUL byte not removed: {result}");
-        assert!(!result.contains('\0'), "NUL byte present in result: {result}");
+        assert!(
+            !result.contains('\0'),
+            "NUL byte present in result: {result}"
+        );
     }
 
     // ── dry run ──────────────────────────────────────────────────────────────
@@ -252,9 +275,15 @@ mod tests {
         let result = rename_file(&src_path, &t, "%t", true).expect("ok");
 
         // Source still exists
-        assert!(fs::metadata(&src_path).is_ok(), "source was deleted in dry-run");
+        assert!(
+            fs::metadata(&src_path).is_ok(),
+            "source was deleted in dry-run"
+        );
         // Destination (result path) does not exist
-        assert!(fs::metadata(&result).is_err(), "destination was created in dry-run");
+        assert!(
+            fs::metadata(&result).is_err(),
+            "destination was created in dry-run"
+        );
     }
 
     // ── actual rename ────────────────────────────────────────────────────────
@@ -269,8 +298,14 @@ mod tests {
         let t = tags(&[("Title", "RenamedFile")]);
         let result = rename_file(&src_str, &t, "%t", false).expect("rename should succeed");
 
-        assert!(fs::metadata(&src_str).is_err(), "source still exists after rename");
-        assert!(fs::metadata(&result).is_ok(), "destination does not exist after rename");
+        assert!(
+            fs::metadata(&src_str).is_err(),
+            "source still exists after rename"
+        );
+        assert!(
+            fs::metadata(&result).is_ok(),
+            "destination does not exist after rename"
+        );
     }
 
     // ── same-filename guard ──────────────────────────────────────────────────

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -153,7 +153,7 @@ mod tests {
         let result = rename_file("some_file.epub", &tags(&[]), "", false);
         assert!(result.is_err());
         assert_eq!(
-            result.unwrap_err().to_string(),
+            result.expect_err("should fail").to_string(),
             "No rename pattern provided"
         );
     }
@@ -163,7 +163,7 @@ mod tests {
         // Pattern "." becomes "" after the '.' sanitisation step
         let result = rename_file("some_file.epub", &tags(&[]), ".", false);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "No new filename generated");
+        assert_eq!(result.expect_err("should fail").to_string(), "No new filename generated");
     }
 
     // ── tag substitution ────────────────────────────────────────────────────
@@ -250,7 +250,7 @@ mod tests {
         // After stripping forbidden chars the stem is empty → error
         let result = rename_file("placeholder.epub", &tags(&[]), "*<>", false);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "No new filename generated");
+        assert_eq!(result.expect_err("should fail").to_string(), "No new filename generated");
     }
 
     #[test]

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -163,7 +163,10 @@ mod tests {
         // Pattern "." becomes "" after the '.' sanitisation step
         let result = rename_file("some_file.epub", &tags(&[]), ".", false);
         assert!(result.is_err());
-        assert_eq!(result.expect_err("should fail").to_string(), "No new filename generated");
+        assert_eq!(
+            result.expect_err("should fail").to_string(),
+            "No new filename generated"
+        );
     }
 
     // ── tag substitution ────────────────────────────────────────────────────
@@ -250,7 +253,10 @@ mod tests {
         // After stripping forbidden chars the stem is empty → error
         let result = rename_file("placeholder.epub", &tags(&[]), "*<>", false);
         assert!(result.is_err());
-        assert_eq!(result.expect_err("should fail").to_string(), "No new filename generated");
+        assert_eq!(
+            result.expect_err("should fail").to_string(),
+            "No new filename generated"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **CI** (`.github/workflows/ci.yml`): runs on every push/PR to `main`
  - `cargo fmt --check`
  - `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used`
  - `cargo nextest run --locked`
  - `cargo build --release --locked`
  - Uses `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, `taiki-e/install-action@cargo-nextest`
  - Minimal permissions: `contents: read`
- **Version**: `0.3.5` → `0.3.6`

Closes meta-ltd.

## Test plan
- [x] `just lint` — zero warnings
- [x] `cargo nextest run` — 21/21 pass
- [x] CI workflow triggers on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)