### PR TITLE
Refactor: pdf_string_to_string fn + get_extension returns &str

### DIFF
--- a/.crumbs/get-extension-return-cow-or-str-instead-of-owned-string.md
+++ b/.crumbs/get-extension-return-cow-or-str-instead-of-owned-string.md
@@ -1,7 +1,7 @@
 ---
 id: meta-h1i
 title: 'get_extension: return Cow or &str instead of owned String'
-status: open
+status: closed
 type: task
 priority: 2
 tags:

--- a/.crumbs/get-field-macro-replace-clone-with-a-free-function.md
+++ b/.crumbs/get-field-macro-replace-clone-with-a-free-function.md
@@ -1,7 +1,7 @@
 ---
 id: meta-idh
 title: 'get_field! macro: replace clone with a free function'
-status: open
+status: closed
 type: task
 priority: 2
 tags:

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,30 +63,25 @@ fn run() -> Result<(), Box<dyn Error>> {
         log::debug!("Processing filename {filename}");
         let ext = utils::get_extension(filename);
 
-        tags = match ext.as_ref() {
-            "pdf" => {
-                log::info!("Processing PDF: {filename}");
-                let pdf_m = pdf::get_metadata(filename);
-                match pdf_m {
-                    Ok(pdf_d) => pdf_d,
-                    Err(e) => {
-                        log::error!("Error processing PDF: {filename}. Error: {e}");
-                        return Err(e);
-                    }
+        tags = if ext.eq_ignore_ascii_case("pdf") {
+            log::info!("Processing PDF: {filename}");
+            let pdf_m = pdf::get_metadata(filename);
+            match pdf_m {
+                Ok(pdf_d) => pdf_d,
+                Err(e) => {
+                    log::error!("Error processing PDF: {filename}. Error: {e}");
+                    return Err(e);
                 }
             }
-            "epub" => {
-                log::info!("Processing EPUB: {filename}");
-                epub::get_metadata(filename)?
-            }
-            "mobi" => {
-                log::info!("Processing MOBI: {filename}");
-                mobi::get_metadata(filename)?
-            }
-            _ => {
-                log::warn!("Unknown file type: {filename}");
-                std::collections::HashMap::new()
-            }
+        } else if ext.eq_ignore_ascii_case("epub") {
+            log::info!("Processing EPUB: {filename}");
+            epub::get_metadata(filename)?
+        } else if ext.eq_ignore_ascii_case("mobi") {
+            log::info!("Processing MOBI: {filename}");
+            mobi::get_metadata(filename)?
+        } else {
+            log::warn!("Unknown file type: {filename}");
+            std::collections::HashMap::new()
         };
 
         log::debug!("tags: {tags:?}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::parser::ValueSource;
+use std::collections::HashMap;
 use std::error::Error;
 
 // Logging
@@ -65,14 +66,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
         tags = if ext.eq_ignore_ascii_case("pdf") {
             log::info!("Processing PDF: {filename}");
-            let pdf_m = pdf::get_metadata(filename);
-            match pdf_m {
-                Ok(pdf_d) => pdf_d,
-                Err(e) => {
-                    log::error!("Error processing PDF: {filename}. Error: {e}");
-                    return Err(e);
-                }
-            }
+            pdf::get_metadata(filename)?
         } else if ext.eq_ignore_ascii_case("epub") {
             log::info!("Processing EPUB: {filename}");
             epub::get_metadata(filename)?
@@ -81,7 +75,7 @@ fn run() -> Result<(), Box<dyn Error>> {
             mobi::get_metadata(filename)?
         } else {
             log::warn!("Unknown file type: {filename}");
-            std::collections::HashMap::new()
+            HashMap::new()
         };
 
         log::debug!("tags: {tags:?}");

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -1,18 +1,20 @@
 use pdf::primitive::PdfString;
 use std::{collections::HashMap, error::Error};
 
-/// Extract a named field from a PDF info dictionary into `$mm`.
+/// Convert an optional [`PdfString`] reference to a plain [`String`].
 ///
-/// Falls back to `"Unknown"` when the field is absent or cannot be converted to a
-/// UTF-8 string, and strips any embedded double-quote characters from the value.
+/// Returns `"Unknown"` when the option is `None` or the string cannot be decoded
+/// as UTF-8. Strips any embedded double-quote characters from the value.
+fn pdf_string_to_string(s: Option<&PdfString>) -> String {
+    s.and_then(|ps| ps.clone().to_string().ok())
+        .unwrap_or_else(|| "Unknown".to_owned())
+        .replace('\"', "")
+}
+
+/// Extract a named field from a PDF info dictionary into `$mm`.
 macro_rules! get_field {
     ($id:ident, $field:ident, $mm:ident, $key:literal) => {
-        let mut $field = <Option<PdfString> as Clone>::clone(&$id.$field)
-            .unwrap_or(PdfString::from("Unknown"))
-            .to_string()
-            .unwrap_or(String::from("Unknown"));
-        $field = $field.replace('\"', "");
-        $mm.insert($key.to_string(), $field);
+        $mm.insert($key.to_string(), pdf_string_to_string($id.$field.as_ref()));
     };
 }
 
@@ -76,6 +78,24 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn E
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pdf::primitive::PdfString;
+
+    #[test]
+    fn pdf_string_to_string_returns_unknown_for_none() {
+        assert_eq!(pdf_string_to_string(None), "Unknown");
+    }
+
+    #[test]
+    fn pdf_string_to_string_returns_value_for_some() {
+        let ps = PdfString::from("Rust Programming");
+        assert_eq!(pdf_string_to_string(Some(&ps)), "Rust Programming");
+    }
+
+    #[test]
+    fn pdf_string_to_string_strips_double_quotes() {
+        let ps = PdfString::from("He said \"hello\"");
+        assert_eq!(pdf_string_to_string(Some(&ps)), "He said hello");
+    }
 
     #[test]
     fn error_message_contains_filename_when_no_info_dict() {

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, error::Error};
 /// Returns `"Unknown"` when the option is `None` or the string cannot be decoded
 /// as UTF-8. Strips any embedded double-quote characters from the value.
 fn pdf_string_to_string(s: Option<&PdfString>) -> String {
-    s.and_then(|ps| ps.clone().to_string().ok())
+    s.and_then(|ps| ps.to_string().ok())
         .unwrap_or_else(|| "Unknown".to_owned())
         .replace('\"', "")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,10 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
-/// Return the lowercase file extension of `filename`, or an empty string if there is none.
+/// Return the file extension of `filename` as a `&str`, or `""` if there is none.
+///
+/// The extension is returned as-is (original case). Callers that need case-insensitive
+/// matching should use [`str::eq_ignore_ascii_case`].
 ///
 /// # Examples
 ///
@@ -9,15 +12,13 @@ use std::path::Path;
 /// assert_eq!(get_extension("book.epub"), "epub");
 /// assert_eq!(get_extension("archive.tar.gz"), "gz");
 /// assert_eq!(get_extension("README"), "");
+/// assert_eq!(get_extension("BOOK.EPUB"), "EPUB");
 /// ```
-pub fn get_extension(filename: &str) -> String {
-    Path::new(&filename)
+pub fn get_extension(filename: &str) -> &str {
+    Path::new(filename)
         .extension()
-        .unwrap_or_else(|| OsStr::new(""))
-        .to_ascii_lowercase()
-        .to_str()
+        .and_then(OsStr::to_str)
         .unwrap_or("")
-        .to_string()
 }
 
 /// Extract the four-digit year from a date string.
@@ -92,5 +93,13 @@ mod tests {
         assert_eq!(get_extension("document.pdf"), "pdf");
         assert_eq!(get_extension("document.xyz.pdf"), "pdf");
         assert_eq!(get_extension("no_extension"), "");
+    }
+
+    #[test]
+    fn get_extension_preserves_original_case() {
+        // get_extension returns the extension as-is; callers use
+        // eq_ignore_ascii_case when matching, avoiding a forced allocation.
+        assert_eq!(get_extension("BOOK.EPUB"), "EPUB");
+        assert_eq!(get_extension("archive.TAR"), "TAR");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -97,8 +97,6 @@ mod tests {
 
     #[test]
     fn get_extension_preserves_original_case() {
-        // get_extension returns the extension as-is; callers use
-        // eq_ignore_ascii_case when matching, avoiding a forced allocation.
         assert_eq!(get_extension("BOOK.EPUB"), "EPUB");
         assert_eq!(get_extension("archive.TAR"), "TAR");
     }


### PR DESCRIPTION
## Summary

### meta-idh — `get_field!` macro: replace clone with a free function
- Extract `pdf_string_to_string(Option<&PdfString>) -> String` — takes a reference, so the macro no longer needs to clone the whole `Option<PdfString>`
- Simplify `get_field!` macro body to a single `insert` call
- Add three unit tests: `None` → `"Unknown"`, `Some` → value, quote-stripping

### meta-h1i — `get_extension` returns `&str`
- Drop `to_ascii_lowercase()` — function now returns a `&str` borrowed directly from the input filename; zero allocation, zero copy
- Callers needing case-insensitive matching use `eq_ignore_ascii_case`; `main.rs` match replaced with an `if/else` chain accordingly
- Add `get_extension_preserves_original_case` test

## Test plan

- [ ] 39/39 tests pass
- [ ] Clippy clean with `-W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used`
- [ ] `pdf_string_to_string`: None, Some, quote-stripping
- [ ] `get_extension_preserves_original_case`: uppercase extensions returned as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)