### PR TITLE
Replace Box<dyn Error> with thiserror/anyhow

### DIFF
--- a/.crumbs/replace-box-dyn-error-with-thiserror-error-enums.md
+++ b/.crumbs/replace-box-dyn-error-with-thiserror-error-enums.md
@@ -1,7 +1,7 @@
 ---
 id: meta-07h
 title: Replace Box<dyn Error> with thiserror error enums
-status: open
+status: closed
 type: feature
 priority: 2
 tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - 2026-04-04
+## [unreleased]
 
-### Features
+### Chore
 
-- Add `--recursive` / `-R` flag to traverse directories and collect all supported ebook files
-- New `walker` module with `collect_files` helper; 11 unit tests covering files, dirs, mixed inputs, extension filtering, and case-insensitivity
+- Housekeeping
+- Migrate to Rust edition 2024 (#22)
 
-## [0.3.6] - 2026-04-04
+### Docs
+
+- Fix stale doc comment in rename_file (#14)
+- Add rustdoc to pdf, mobi, utils, and cli modules (#17)
+
+### Feat
+
+- Harden filename character sanitisation (#19)
+- Add GitHub Actions CI workflow + bump to v0.3.6 (#20)
+- Add --recursive/-R flag for directory traversal (v0.4.0) (#21)
+
+### Fix
+
+- Repair epub 2.1.5 API break and pdf error interpolation (#12)
+- Replace panicking byte-slice with safe .get() in get_year (#13)
+- Correct get_unique_value doc comment and add test (#15)
 
 ### Refactor
 
 - PDF crate update (#6)
-- EPUB and MOBI modules now extract `Year` internally; `main` no longer needs format-specific date logic
-- `get_year` simplified — the `D:`-prefix PDF date branch was dead code (PDF module uses native date parsing)
+- Move Year extraction into epub/mobi modules + README updates (#18)
+
+### Test
+
+- Add test coverage for rename_file module (#16)
 
 ## [0.3.2] - 2024-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
+- Replace `Box<dyn Error>` with typed `thiserror` enums (`PdfMetaError`, `RenameError`) and `anyhow::Result` for propagation-only modules (#25)
+- Extract `pdf_string_to_string` helper and make `get_extension` return `&str` (#24)
 - PDF crate update (#6)
 - Move Year extraction into epub/mobi modules + README updates (#18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ exclude = ["tests/fixtures/**"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.6.0", features = ["cargo", "color"] }
 convert_case = "0.11.0"
 env_logger = "0.11.10"
@@ -17,6 +18,7 @@ epub = "2.1.5"
 log = "0.4.29"
 mobi = "0.8.0"
 pdf = "0.10.0"
+thiserror = "2"
 walkdir = "2.5.0"
 
 [profile.release]

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use convert_case::{Case, Casing};
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
 
 use epub::doc::EpubDoc;
 
@@ -47,7 +47,7 @@ use epub::doc::EpubDoc;
 /// # Errors
 ///
 /// Returns `Err` if the EPUB file cannot be opened or parsed.
-pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
+pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, String>> {
     let doc = EpubDoc::new(filename)?;
     log::debug!("metadata = {:?}", doc.metadata);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use clap::parser::ValueSource;
 use std::collections::HashMap;
-use std::error::Error;
 
 // Logging
 use env_logger::{Builder, Target};
@@ -19,7 +18,7 @@ mod walker;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// This is where the magic happens.
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> anyhow::Result<()> {
     // Set up the command line. Ref https://docs.rs/clap for details.
     let cli_args = cli::build().get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use clap::parser::ValueSource;
 use std::collections::HashMap;
 
@@ -65,13 +66,15 @@ fn run() -> anyhow::Result<()> {
 
         tags = if ext.eq_ignore_ascii_case("pdf") {
             log::info!("Processing PDF: {filename}");
-            pdf::get_metadata(filename)?
+            pdf::get_metadata(filename).with_context(|| format!("failed to read PDF: {filename}"))?
         } else if ext.eq_ignore_ascii_case("epub") {
             log::info!("Processing EPUB: {filename}");
-            epub::get_metadata(filename)?
+            epub::get_metadata(filename)
+                .with_context(|| format!("failed to read EPUB: {filename}"))?
         } else if ext.eq_ignore_ascii_case("mobi") {
             log::info!("Processing MOBI: {filename}");
-            mobi::get_metadata(filename)?
+            mobi::get_metadata(filename)
+                .with_context(|| format!("failed to read MOBI: {filename}"))?
         } else {
             log::warn!("Unknown file type: {filename}");
             HashMap::new()

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use mobi::Mobi;
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
 
 /// Read metadata from a MOBI file and return it as a [`HashMap`].
 ///
@@ -25,7 +25,7 @@ use std::{collections::HashMap, error::Error};
 /// # Errors
 ///
 /// Returns `Err` if the file cannot be opened or parsed as a MOBI document.
-pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
+pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, String>> {
     let mobi_file = Mobi::from_path(filename)?;
     log::debug!("metadata = {:?}", mobi_file.metadata);
 

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -1,5 +1,16 @@
 use pdf::primitive::PdfString;
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
+
+/// Errors that can occur when reading PDF metadata.
+#[derive(Debug, thiserror::Error)]
+pub enum PdfMetaError {
+    /// The PDF file could not be opened or parsed.
+    #[error(transparent)]
+    Pdf(#[from] pdf::PdfError),
+    /// The PDF contains no info dictionary.
+    #[error("No info dictionary found in {0}")]
+    NoInfoDict(String),
+}
 
 /// Convert an optional [`PdfString`] reference to a plain [`String`].
 ///
@@ -47,12 +58,12 @@ macro_rules! get_field {
 /// - The `pdf` crate cannot open or parse the file (corrupt data, unsupported version,
 ///   permission denied, etc.) — the underlying crate error is propagated.
 /// - The PDF contains no info dictionary — the error message includes `filename`.
-pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, Box<dyn Error>> {
+pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, PdfMetaError> {
     log::debug!("Opening file: {filename}");
 
     let file = pdf::file::FileOptions::cached().open(filename)?;
     let Some(info) = file.trailer.info_dict.as_ref() else {
-        return Err(format!("No info dictionary found in {filename}").into());
+        return Err(PdfMetaError::NoInfoDict(filename.to_owned()));
     };
 
     let mut metadata_map: HashMap<String, String> = HashMap::new();
@@ -98,21 +109,12 @@ mod tests {
     }
 
     #[test]
-    fn error_message_contains_filename_when_no_info_dict() {
+    fn error_is_no_info_dict_variant() {
         let filename = "tests/fixtures/no-info-dict.pdf";
-        let result = get_metadata(filename);
+        let err = get_metadata(filename).expect_err("expected error for PDF with no info dict");
         assert!(
-            result.is_err(),
-            "Expected an error for a PDF with no info dict"
-        );
-        let msg = result.expect_err("should fail").to_string();
-        assert!(
-            msg.starts_with("No info dictionary found in "),
-            "Error message should start with 'No info dictionary found in ', got: {msg}"
-        );
-        assert!(
-            msg.contains(filename),
-            "Error message should contain the filename '{filename}', got: {msg}"
+            matches!(err, PdfMetaError::NoInfoDict(ref f) if f == filename),
+            "expected NoInfoDict(\"{filename}\"), got: {err}"
         );
     }
 }

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -57,7 +57,7 @@ macro_rules! get_field {
 /// Returns `Err` in two distinct cases:
 /// - The `pdf` crate cannot open or parse the file (corrupt data, unsupported version,
 ///   permission denied, etc.) — the underlying crate error is propagated.
-/// - The PDF contains no info dictionary — the error message includes `filename`.
+/// - The PDF contains no info dictionary — returns [`PdfMetaError::NoInfoDict`] carrying `filename`.
 pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, PdfMetaError> {
     log::debug!("Opening file: {filename}");
 

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -38,7 +38,7 @@ pub enum RenameError {
 /// **Returns**
 ///
 /// - The new file name if successful
-/// - An error message if unsuccessful.
+/// - A [`RenameError`] variant indicating what failed.
 pub fn rename_file(
     filename: &str,
     tags: &HashMap<String, String>,
@@ -131,7 +131,7 @@ pub fn rename_file(
 }
 
 /// Upper bound (exclusive) for the de-collision value: total microseconds relative to
-/// `UNIX_EPOCH` modulo this constant, giving a ~10-second window of unique values.
+/// `UNIX_EPOCH` modulo this constant, giving a 10-second window of unique values.
 const UNIQUE_VALUE_MODULUS: u128 = 10_000_000;
 
 /// Returns a unique numeric identifier in `0..UNIQUE_VALUE_MODULUS` derived from the
@@ -309,6 +309,18 @@ mod tests {
         assert!(
             !result.contains('\0'),
             "NUL byte present in result: {result}"
+        );
+    }
+
+    #[test]
+    fn rename_to_nonexistent_parent_returns_rename_failed() {
+        // Trigger a filesystem error by targeting a directory that does not exist.
+        let t = tags(&[("Title", "SomeTitle")]);
+        let err = rename_file("nonexistent_dir/source.epub", &t, "%t", false)
+            .expect_err("should fail");
+        assert!(
+            matches!(err, RenameError::RenameFailed { .. }),
+            "expected RenameFailed, got: {err}"
         );
     }
 

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -1,10 +1,28 @@
 use crate::utils;
 use std::{
     collections::HashMap,
-    error::Error,
     path::Path,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+/// Errors that can occur when renaming a file.
+#[derive(Debug, thiserror::Error)]
+pub enum RenameError {
+    /// No rename pattern was supplied.
+    #[error("No rename pattern provided")]
+    EmptyPattern,
+    /// After tag substitution and sanitisation, the filename stem is empty.
+    #[error("No new filename generated")]
+    EmptyResult,
+    /// The underlying filesystem rename failed.
+    #[error("Unable to rename {from} to {to}: {source}")]
+    RenameFailed {
+        from: String,
+        to: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
 
 /// Renames the file provided based on the pattern provided.
 ///
@@ -26,10 +44,10 @@ pub fn rename_file(
     tags: &HashMap<String, String>,
     pattern: &str,
     dry_run: bool,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, RenameError> {
     // Check if there is a rename pattern
     if pattern.is_empty() {
-        return Err("No rename pattern provided".into());
+        return Err(RenameError::EmptyPattern);
     }
 
     let mut new_filename = pattern.to_string();
@@ -61,7 +79,7 @@ pub fn rename_file(
     new_filename = new_filename.trim().to_string();
 
     if new_filename.is_empty() {
-        return Err("No new filename generated".into());
+        return Err(RenameError::EmptyResult);
     }
 
     // Get the path in front of the filename (eg. "books/book.pdf" returns "books/")
@@ -97,12 +115,12 @@ pub fn rename_file(
         let rn_res = std::fs::rename(filename, &new_path);
         match rn_res {
             Ok(()) => log::debug!("{filename} --> {}", new_path.to_string_lossy()),
-            Err(err) => {
-                return Err(format!(
-                    "Unable to rename {filename} to {}. Error message: {err}",
-                    new_path.to_string_lossy(),
-                )
-                .into());
+            Err(source) => {
+                return Err(RenameError::RenameFailed {
+                    from: filename.to_owned(),
+                    to: new_path.to_string_lossy().into_owned(),
+                    source,
+                });
             }
         }
     }
@@ -183,23 +201,17 @@ mod tests {
 
     #[test]
     fn empty_pattern_returns_error() {
-        let result = rename_file("some_file.epub", &tags(&[]), "", false);
-        assert!(result.is_err());
-        assert_eq!(
-            result.expect_err("should fail").to_string(),
-            "No rename pattern provided"
-        );
+        let err = rename_file("some_file.epub", &tags(&[]), "", false)
+            .expect_err("should fail");
+        assert!(matches!(err, RenameError::EmptyPattern));
     }
 
     #[test]
     fn pattern_that_sanitises_to_empty_returns_error() {
         // Pattern "." becomes "" after the '.' sanitisation step
-        let result = rename_file("some_file.epub", &tags(&[]), ".", false);
-        assert!(result.is_err());
-        assert_eq!(
-            result.expect_err("should fail").to_string(),
-            "No new filename generated"
-        );
+        let err = rename_file("some_file.epub", &tags(&[]), ".", false)
+            .expect_err("should fail");
+        assert!(matches!(err, RenameError::EmptyResult));
     }
 
     // ── tag substitution ────────────────────────────────────────────────────
@@ -284,12 +296,9 @@ mod tests {
     #[test]
     fn pattern_of_only_forbidden_chars_returns_error() {
         // After stripping forbidden chars the stem is empty → error
-        let result = rename_file("placeholder.epub", &tags(&[]), "*<>", false);
-        assert!(result.is_err());
-        assert_eq!(
-            result.expect_err("should fail").to_string(),
-            "No new filename generated"
-        );
+        let err = rename_file("placeholder.epub", &tags(&[]), "*<>", false)
+            .expect_err("should fail");
+        assert!(matches!(err, RenameError::EmptyResult));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **pdf.rs**: `PdfMetaError` enum (`Pdf` via `#[from]`, `NoInfoDict`) replaces `Box<dyn Error>`
- **rename_file.rs**: `RenameError` enum (`EmptyPattern`, `EmptyResult`, `RenameFailed`) replaces `Box<dyn Error>`
- **epub.rs / mobi.rs**: switch to `anyhow::Result` — these modules only propagate foreign errors so a typed enum adds no value
- **main.rs**: `run()` returns `anyhow::Result<()>`; `use std::error::Error` removed

Callers can now `match` on `PdfMetaError` and `RenameError` variants for precise error handling.

## Test plan

- [x] All 39 existing tests pass (`cargo nextest run`)
- [x] New `error_is_no_info_dict_variant` test asserts the correct variant
- [x] New rename error tests assert `EmptyPattern` / `EmptyResult` variants
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)