### PR TITLE
Replace sentinel strings with Option<String> in metadata maps

### DIFF
--- a/.crumbs/metadata-hashmap-replace-unknown-sentinel-with-option-string.md
+++ b/.crumbs/metadata-hashmap-replace-unknown-sentinel-with-option-string.md
@@ -1,7 +1,7 @@
 ---
 id: meta-akx
 title: 'Metadata HashMap: replace "Unknown" sentinel with Option<String>'
-status: open
+status: closed
 type: feature
 priority: 2
 tags:

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -47,11 +47,11 @@ use epub::doc::EpubDoc;
 /// # Errors
 ///
 /// Returns `Err` if the EPUB file cannot be opened or parsed.
-pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, String>> {
+pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, Option<String>>> {
     let doc = EpubDoc::new(filename)?;
     log::debug!("metadata = {:?}", doc.metadata);
 
-    let mut metadata_map: HashMap<String, String> = HashMap::new();
+    let mut metadata_map: HashMap<String, Option<String>> = HashMap::new();
 
     let keys = vec![
         "title",
@@ -64,21 +64,23 @@ pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, String>> {
     ];
 
     for key in keys {
-        if let Some(item) = doc.mdata(key) {
+        let value = doc.mdata(key).map(|item| {
             log::debug!("{key} = {:?}", item.value);
-            metadata_map.insert(key.to_string().to_case(Case::Title), item.value.clone());
-        } else {
+            item.value.clone()
+        });
+        if value.is_none() {
             log::debug!("No {key} found in metadata.");
-            metadata_map.insert(key.to_string().to_case(Case::Title), String::new());
         }
+        metadata_map.insert(key.to_string().to_case(Case::Title), value);
     }
 
     // Extract year from the date string and store it alongside
-    let date = metadata_map
+    let year = metadata_map
         .get("Date")
-        .map_or("", String::as_str)
-        .to_owned();
-    metadata_map.insert("Year".to_string(), utils::get_year(&date));
+        .and_then(Option::as_deref)
+        .map(utils::get_year)
+        .filter(|y| !y.is_empty());
+    metadata_map.insert("Year".to_string(), year);
 
     // return the metadata
     log::debug!("metadata_map = {metadata_map:?}");
@@ -93,7 +95,7 @@ mod tests {
     fn get_metadata_includes_year_key() {
         let map = get_metadata("tests/fixtures/Mastering.epub").expect("should parse");
         assert_eq!(
-            map.get("Year").map(String::as_str),
+            map.get("Year").and_then(Option::as_deref),
             Some("2019"),
             "unexpected Year value"
         );

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -24,8 +24,8 @@ use epub::doc::EpubDoc;
 /// * `Identifier` - The identifier of the EPUB file.
 /// * `Year` - The four-digit year extracted from `Date`.
 ///
-/// Keys are title-cased (e.g. `"Title"`, `"Author"`). If a metadata field is
-/// absent the key is still present in the map with an empty string value.
+/// Keys are title-cased (e.g. `"Title"`, `"Author"`). Values are `Option<String>`:
+/// `None` when the field is absent from the file, `Some(value)` otherwise.
 ///
 /// # Example
 ///
@@ -33,14 +33,14 @@ use epub::doc::EpubDoc;
 /// use std::collections::HashMap;
 /// use docmeta::epub::get_metadata;
 /// let metadata = get_metadata("tests/test.epub").unwrap();
-/// let mut expected_metadata: HashMap<String, String> = HashMap::new();
-/// expected_metadata.insert("Title".to_string(), "The Title".to_string());
-/// expected_metadata.insert("Author".to_string(), "The Author".to_string());
-/// expected_metadata.insert("Description".to_string(), "The Description".to_string());
-/// expected_metadata.insert("Publisher".to_string(), "The Publisher".to_string());
-/// expected_metadata.insert("Date".to_string(), "2021-01-01".to_string());
-/// expected_metadata.insert("Language".to_string(), "en".to_string());
-/// expected_metadata.insert("Identifier".to_string(), "urn:isbn:978-3-16-148410-0".to_string());
+/// let mut expected_metadata: HashMap<String, Option<String>> = HashMap::new();
+/// expected_metadata.insert("Title".to_string(), Some("The Title".to_string()));
+/// expected_metadata.insert("Author".to_string(), Some("The Author".to_string()));
+/// expected_metadata.insert("Description".to_string(), Some("The Description".to_string()));
+/// expected_metadata.insert("Publisher".to_string(), Some("The Publisher".to_string()));
+/// expected_metadata.insert("Date".to_string(), Some("2021-01-01".to_string()));
+/// expected_metadata.insert("Language".to_string(), Some("en".to_string()));
+/// expected_metadata.insert("Identifier".to_string(), Some("urn:isbn:978-3-16-148410-0".to_string()));
 /// assert_eq!(metadata, expected_metadata);
 /// ```
 ///

--- a/src/epub.rs
+++ b/src/epub.rs
@@ -41,6 +41,7 @@ use epub::doc::EpubDoc;
 /// expected_metadata.insert("Date".to_string(), Some("2021-01-01".to_string()));
 /// expected_metadata.insert("Language".to_string(), Some("en".to_string()));
 /// expected_metadata.insert("Identifier".to_string(), Some("urn:isbn:978-3-16-148410-0".to_string()));
+/// expected_metadata.insert("Year".to_string(), Some("2021".to_string()));
 /// assert_eq!(metadata, expected_metadata);
 /// ```
 ///

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -15,12 +15,12 @@ use std::collections::HashMap;
 /// | Key | Source field |
 /// |-----|-------------|
 /// | `"Title"` | Book title |
-/// | `"Author"` | Author name, or empty string if absent |
-/// | `"Description"` | Book description, or empty string if absent |
-/// | `"Publisher"` | Publisher name, or empty string if absent |
-/// | `"Identifier"` | ISBN, or empty string if absent |
-/// | `"Date"` | Publish date string, or empty string if absent |
-/// | `"Year"` | Four-digit year extracted from `Date`, or empty string if absent |
+/// | `"Author"` | Author name, or `None` if absent |
+/// | `"Description"` | Book description, or `None` if absent |
+/// | `"Publisher"` | Publisher name, or `None` if absent |
+/// | `"Identifier"` | ISBN, or `None` if absent |
+/// | `"Date"` | Publish date string, or `None` if absent |
+/// | `"Year"` | Four-digit year extracted from `Date`, or `None` if absent |
 ///
 /// # Errors
 ///

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -25,40 +25,26 @@ use std::collections::HashMap;
 /// # Errors
 ///
 /// Returns `Err` if the file cannot be opened or parsed as a MOBI document.
-pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, String>> {
+pub fn get_metadata(filename: &str) -> anyhow::Result<HashMap<String, Option<String>>> {
     let mobi_file = Mobi::from_path(filename)?;
     log::debug!("metadata = {:?}", mobi_file.metadata);
 
-    let mut metadata_map: HashMap<String, String> = HashMap::new();
+    let mut metadata_map: HashMap<String, Option<String>> = HashMap::new();
 
-    metadata_map.insert("Title".to_string(), mobi_file.title());
-    metadata_map.insert(
-        "Author".to_string(),
-        mobi_file.author().unwrap_or_else(String::new),
-    );
-    metadata_map.insert(
-        "Description".to_string(),
-        mobi_file.description().unwrap_or_else(String::new),
-    );
-    metadata_map.insert(
-        "Publisher".to_string(),
-        mobi_file.publisher().unwrap_or_else(String::new),
-    );
-    metadata_map.insert(
-        "Identifier".to_string(),
-        mobi_file.isbn().unwrap_or_else(String::new),
-    );
-    metadata_map.insert(
-        "Date".to_string(),
-        mobi_file.publish_date().unwrap_or_else(String::new),
-    );
+    metadata_map.insert("Title".to_string(), Some(mobi_file.title()));
+    metadata_map.insert("Author".to_string(), mobi_file.author());
+    metadata_map.insert("Description".to_string(), mobi_file.description());
+    metadata_map.insert("Publisher".to_string(), mobi_file.publisher());
+    metadata_map.insert("Identifier".to_string(), mobi_file.isbn());
+    metadata_map.insert("Date".to_string(), mobi_file.publish_date());
 
     // Extract year from the date string and store it alongside
-    let date = metadata_map
+    let year = metadata_map
         .get("Date")
-        .map_or("", String::as_str)
-        .to_owned();
-    metadata_map.insert("Year".to_string(), utils::get_year(&date));
+        .and_then(Option::as_deref)
+        .map(utils::get_year)
+        .filter(|y| !y.is_empty());
+    metadata_map.insert("Year".to_string(), year);
 
     log::debug!("metadata_map = {metadata_map:?}");
 
@@ -74,7 +60,7 @@ mod tests {
     fn get_metadata_includes_year_key() {
         let map = get_metadata("tests/fixtures/Mastering.mobi").expect("should parse");
         assert_eq!(
-            map.get("Year").map(String::as_str),
+            map.get("Year").and_then(Option::as_deref),
             Some("2019"),
             "unexpected Year value"
         );

--- a/src/mobi.rs
+++ b/src/mobi.rs
@@ -10,7 +10,8 @@ use std::collections::HashMap;
 ///
 /// # Returns
 ///
-/// A [`HashMap`] containing the following keys (all `String` values):
+/// A [`HashMap`] containing the following keys. Values are `Option<String>`:
+/// `None` when the field is absent, `Some(value)` otherwise.
 ///
 /// | Key | Source field |
 /// |-----|-------------|

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -12,14 +12,13 @@ pub enum PdfMetaError {
     NoInfoDict(String),
 }
 
-/// Convert an optional [`PdfString`] reference to a plain [`String`].
+/// Convert an optional [`PdfString`] reference to an `Option<String>`.
 ///
-/// Returns `"Unknown"` when the option is `None` or the string cannot be decoded
-/// as UTF-8. Strips any embedded double-quote characters from the value.
-fn pdf_string_to_string(s: Option<&PdfString>) -> String {
+/// Returns `None` when the option is `None` or the string cannot be decoded as
+/// UTF-8. Strips any embedded double-quote characters from the value.
+fn pdf_string_to_string(s: Option<&PdfString>) -> Option<String> {
     s.and_then(|ps| ps.to_string().ok())
-        .unwrap_or_else(|| "Unknown".to_owned())
-        .replace('\"', "")
+        .map(|v| v.replace('\"', ""))
 }
 
 /// Extract a named field from a PDF info dictionary into `$mm`.
@@ -58,7 +57,7 @@ macro_rules! get_field {
 /// - The `pdf` crate cannot open or parse the file (corrupt data, unsupported version,
 ///   permission denied, etc.) — the underlying crate error is propagated.
 /// - The PDF contains no info dictionary — returns [`PdfMetaError::NoInfoDict`] carrying `filename`.
-pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, PdfMetaError> {
+pub fn get_metadata(filename: &str) -> Result<HashMap<String, Option<String>>, PdfMetaError> {
     log::debug!("Opening file: {filename}");
 
     let file = pdf::file::FileOptions::cached().open(filename)?;
@@ -66,7 +65,7 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, PdfMetaEr
         return Err(PdfMetaError::NoInfoDict(filename.to_owned()));
     };
 
-    let mut metadata_map: HashMap<String, String> = HashMap::new();
+    let mut metadata_map: HashMap<String, Option<String>> = HashMap::new();
 
     get_field!(info, author, metadata_map, "Author");
     get_field!(info, title, metadata_map, "Title");
@@ -75,11 +74,12 @@ pub fn get_metadata(filename: &str) -> Result<HashMap<String, String>, PdfMetaEr
     get_field!(info, creator, metadata_map, "Creator");
     get_field!(info, producer, metadata_map, "Producer");
 
-    if let Some(creation_date) = &info.creation_date {
-        metadata_map.insert("Year".to_string(), creation_date.year.to_string());
-    } else {
-        metadata_map.insert("Year".to_string(), String::new());
-    }
+    metadata_map.insert(
+        "Year".to_string(),
+        info.creation_date
+            .as_ref()
+            .map(|d| d.year.to_string()),
+    );
 
     log::debug!("metadata_map: {metadata_map:?}");
 
@@ -92,20 +92,20 @@ mod tests {
     use pdf::primitive::PdfString;
 
     #[test]
-    fn pdf_string_to_string_returns_unknown_for_none() {
-        assert_eq!(pdf_string_to_string(None), "Unknown");
+    fn pdf_string_to_string_returns_none_for_none() {
+        assert_eq!(pdf_string_to_string(None), None);
     }
 
     #[test]
-    fn pdf_string_to_string_returns_value_for_some() {
+    fn pdf_string_to_string_returns_some_for_present_value() {
         let ps = PdfString::from("Rust Programming");
-        assert_eq!(pdf_string_to_string(Some(&ps)), "Rust Programming");
+        assert_eq!(pdf_string_to_string(Some(&ps)), Some("Rust Programming".to_owned()));
     }
 
     #[test]
     fn pdf_string_to_string_strips_double_quotes() {
         let ps = PdfString::from("He said \"hello\"");
-        assert_eq!(pdf_string_to_string(Some(&ps)), "He said hello");
+        assert_eq!(pdf_string_to_string(Some(&ps)), Some("He said hello".to_owned()));
     }
 
     #[test]

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -36,7 +36,8 @@ macro_rules! get_field {
 ///
 /// # Returns
 ///
-/// A [`HashMap`] containing the following keys (all `String` values):
+/// A [`HashMap`] containing the following keys. Values are `Option<String>`:
+/// `None` when the field is absent or cannot be decoded, `Some(value)` otherwise.
 ///
 /// | Key | Source field |
 /// |-----|-------------|
@@ -47,9 +48,6 @@ macro_rules! get_field {
 /// | `"Creator"` | `info.creator` |
 /// | `"Producer"` | `info.producer` |
 /// | `"Year"` | `info.creation_date.year` |
-///
-/// Fields absent from the PDF info dictionary are inserted with the value `"Unknown"`,
-/// except `"Year"` which is inserted as an empty string when the creation date is missing.
 ///
 /// # Errors
 ///

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -41,7 +41,7 @@ pub enum RenameError {
 /// - A [`RenameError`] variant indicating what failed.
 pub fn rename_file(
     filename: &str,
-    tags: &HashMap<String, String>,
+    tags: &HashMap<String, Option<String>>,
     pattern: &str,
     dry_run: bool,
 ) -> Result<String, RenameError> {
@@ -53,17 +53,11 @@ pub fn rename_file(
     let mut new_filename = pattern.to_string();
 
     // replace any options (eg. %aa, %tg) with the corresponding tag
-    new_filename = new_filename.replace("%t", tags.get("Title").map_or("Unknown", String::as_str));
-    new_filename = new_filename.replace("%a", tags.get("Author").map_or("Unknown", String::as_str));
-    new_filename = new_filename.replace(
-        "%p",
-        tags.get("Publisher").map_or("Unknown", String::as_str),
-    );
-    new_filename = new_filename.replace(
-        "%i",
-        tags.get("Identifier").map_or("Unknown", String::as_str),
-    );
-    new_filename = new_filename.replace("%y", tags.get("Year").map_or("Unknown", String::as_str));
+    new_filename = new_filename.replace("%t", tags.get("Title").and_then(Option::as_deref).unwrap_or("Unknown"));
+    new_filename = new_filename.replace("%a", tags.get("Author").and_then(Option::as_deref).unwrap_or("Unknown"));
+    new_filename = new_filename.replace("%p", tags.get("Publisher").and_then(Option::as_deref).unwrap_or("Unknown"));
+    new_filename = new_filename.replace("%i", tags.get("Identifier").and_then(Option::as_deref).unwrap_or("Unknown"));
+    new_filename = new_filename.replace("%y", tags.get("Year").and_then(Option::as_deref).unwrap_or("Unknown"));
 
     // Semantic replacements: preserve readability where possible.
     new_filename = new_filename.replace('/', "-");
@@ -161,10 +155,10 @@ mod tests {
     use std::time::Duration;
     use tempfile::NamedTempFile;
 
-    fn tags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    fn tags(pairs: &[(&str, &str)]) -> HashMap<String, Option<String>> {
         pairs
             .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .map(|(k, v)| ((*k).to_string(), Some((*v).to_string())))
             .collect()
     }
 

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -29,7 +29,7 @@ pub enum RenameError {
 /// **Parameters:**
 ///
 /// - `filename: &str` -- the name of the file to be renamed
-/// - `tags: &HashMap<String, String>` -- The metadata values (e.g. Title, Author, Year, Publisher).
+/// - `tags: &HashMap<String, Option<String>>` -- The metadata values (e.g. Title, Author, Year, Publisher). `None` values fall back to `"Unknown"` in the generated filename.
 /// - `pattern: &str` -- the tag pattern for the new filename. This has been validated to be OK by the CLI.
 /// - `dry_run: bool` -- if `true`, log what would happen but do not rename the file.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,12 +58,11 @@ pub fn get_year(date: &str) -> String {
 /// Print each metadata key/value pair to stdout.
 ///
 /// Empty values are displayed as `"N/A"` rather than a blank.
-pub fn print_metadata(tags: &std::collections::HashMap<String, String>) {
+pub fn print_metadata(tags: &std::collections::HashMap<String, Option<String>>) {
     for (key, value) in tags {
-        if value.is_empty() {
-            println!("{key}: N/A");
-        } else {
-            println!("{key}: {value}");
+        match value {
+            Some(v) => println!("{key}: {v}"),
+            None => println!("{key}: N/A"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- **pdf.rs**: `pdf_string_to_string` now returns `Option<String>` — `None` for absent/undecodable fields instead of the `"Unknown"` sentinel; `get_metadata` return type updated accordingly
- **epub.rs / mobi.rs**: `get_metadata` returns `HashMap<String, Option<String>>`; absent fields are `None`, present fields are `Some(value)`; Year extraction uses `.filter(|y| !y.is_empty())`
- **rename_file.rs**: tag lookups updated to `.and_then(Option::as_deref).unwrap_or("Unknown")` — fallback still renders as `Unknown` in filenames but is now explicit at the call site; function signature updated
- **utils.rs**: `print_metadata` accepts `HashMap<String, Option<String>>`; `None` values display as `N/A`

Callers can now distinguish "field absent from file" (`None`) from "field present but empty" (`Some("")`).

## Test plan

- [x] Updated `pdf_string_to_string` tests: `None` → `None`, `Some` → `Some`
- [x] Updated epub/mobi Year tests to use `.and_then(Option::as_deref)`
- [x] Updated `rename_file` test helper to wrap values in `Some`
- [x] All 40 tests pass (`cargo nextest run`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)