### PR TITLE
collect_files: accept &[impl AsRef<str>] instead of &[String]

### DIFF
--- a/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
+++ b/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
@@ -1,7 +1,7 @@
 ---
 id: meta-m83
 title: 'collect_files: accept &[impl AsRef<str>] instead of &[String]'
-status: open
+status: closed
 type: feature
 priority: 2
 tags:

--- a/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
+++ b/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
@@ -1,7 +1,7 @@
 ---
 id: meta-m83
 title: 'collect_files: accept &[impl AsRef<str>] instead of &[String]'
-status: in_progress
+status: closed
 type: feature
 priority: 2
 tags:

--- a/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
+++ b/.crumbs/collect-files-accept-impl-asref-str-instead-of-string.md
@@ -1,7 +1,7 @@
 ---
 id: meta-m83
 title: 'collect_files: accept &[impl AsRef<str>] instead of &[String]'
-status: closed
+status: in_progress
 type: feature
 priority: 2
 tags:

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn run() -> anyhow::Result<()> {
     // Initialize logging
     logbuilder.target(Target::Stdout).init();
 
-    let inputs: Vec<&String> = cli_args
+    let inputs = cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
-        .collect();
+        .collect::<Vec<_>>();
     let files = walker::collect_files(&inputs, recursive);
 
     // Initialize variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,14 +47,11 @@ fn run() -> anyhow::Result<()> {
     // Initialize logging
     logbuilder.target(Target::Stdout).init();
 
-    let files = walker::collect_files(
-        &cli_args
-            .get_many::<String>("read")
-            .unwrap_or_default()
-            .cloned()
-            .collect::<Vec<_>>(),
-        recursive,
-    );
+    let inputs: Vec<&String> = cli_args
+        .get_many::<String>("read")
+        .unwrap_or_default()
+        .collect();
+    let files = walker::collect_files(&inputs, recursive);
 
     // Initialize variables
     let mut tags;

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -84,7 +84,6 @@ mod tests {
 
     #[test]
     fn accepts_str_literals_without_string_allocation() {
-        // Passes &[&str] directly — would not compile with the old &[String] signature.
         let result = collect_files(&["nonexistent_xyz_path"], false);
         assert!(result.is_empty());
     }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -15,10 +15,11 @@ const SUPPORTED_EXTENSIONS: &[&str] = &["epub", "mobi", "pdf"];
 /// The returned list follows the order of `inputs`: each input's contribution
 /// (the path itself for files, or the sorted directory contents for directories)
 /// is appended when that input is encountered.
-pub fn collect_files(inputs: &[String], recursive: bool) -> Vec<String> {
+pub fn collect_files<S: AsRef<str>>(inputs: &[S], recursive: bool) -> Vec<String> {
     let mut result = Vec::new();
 
     for input in inputs {
+        let input = input.as_ref();
         let meta = match std::fs::metadata(input) {
             Ok(meta) => meta,
             Err(err) => {
@@ -28,7 +29,7 @@ pub fn collect_files(inputs: &[String], recursive: bool) -> Vec<String> {
         };
 
         if meta.is_file() {
-            result.push(input.clone());
+            result.push(input.to_owned());
         } else if meta.is_dir() {
             if !recursive {
                 log::warn!("Directory skipped (use --recursive to traverse): {input}");
@@ -78,6 +79,15 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    // ── &[&str] accepted without allocation ──────────────────────────────────
+
+    #[test]
+    fn accepts_str_literals_without_string_allocation() {
+        // Passes &[&str] directly — would not compile with the old &[String] signature.
+        let result = collect_files(&["nonexistent_xyz_path"], false);
+        assert!(result.is_empty());
+    }
 
     // ── non-existent path ────────────────────────────────────────────────────
 

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -6,7 +6,9 @@ const SUPPORTED_EXTENSIONS: &[&str] = &["epub", "mobi", "pdf"];
 ///
 /// Each entry in `inputs` is treated as follows:
 ///
-/// - **File**: included as-is (regardless of extension or `recursive`).
+/// - **File**: included as-is (regardless of extension or `recursive`), unless its
+///   path is not valid UTF-8, in which case it is skipped with a warning (the return
+///   type `Vec<String>` cannot represent non-UTF-8 paths).
 /// - **Directory** with `recursive = true`: walked depth-first; only files
 ///   whose extensions appear in [`SUPPORTED_EXTENSIONS`] are included.
 /// - **Directory** with `recursive = false`: skipped with a warning.

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -85,7 +85,7 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    // ── &[&str] / &[Path] accepted (generic bound) ───────────────────────────
+    // ── &[&str] / other AsRef<Path> inputs accepted (generic bound) ──────────
 
     #[test]
     fn str_slice_with_real_file_is_returned() {

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -15,7 +15,7 @@ const SUPPORTED_EXTENSIONS: &[&str] = &["epub", "mobi", "pdf"];
 /// The returned list follows the order of `inputs`: each input's contribution
 /// (the path itself for files, or the sorted directory contents for directories)
 /// is appended when that input is encountered.
-pub fn collect_files<S: AsRef<str>>(inputs: &[S], recursive: bool) -> Vec<String> {
+pub fn collect_files<S: AsRef<std::path::Path>>(inputs: &[S], recursive: bool) -> Vec<String> {
     let mut result = Vec::new();
 
     for input in inputs {
@@ -23,16 +23,19 @@ pub fn collect_files<S: AsRef<str>>(inputs: &[S], recursive: bool) -> Vec<String
         let meta = match std::fs::metadata(input) {
             Ok(meta) => meta,
             Err(err) => {
-                log::warn!("Failed to stat path, skipping: {input} ({err})");
+                log::warn!("Failed to stat path, skipping: {} ({err})", input.display());
                 continue;
             }
         };
 
         if meta.is_file() {
-            result.push(input.to_owned());
+            match input.to_str() {
+                Some(s) => result.push(s.to_owned()),
+                None => log::warn!("Skipping non-UTF-8 path: {}", input.display()),
+            }
         } else if meta.is_dir() {
             if !recursive {
-                log::warn!("Directory skipped (use --recursive to traverse): {input}");
+                log::warn!("Directory skipped (use --recursive to traverse): {}", input.display());
                 continue;
             }
             for entry in WalkDir::new(input)
@@ -67,7 +70,7 @@ pub fn collect_files<S: AsRef<str>>(inputs: &[S], recursive: bool) -> Vec<String
                 }
             }
         } else {
-            log::warn!("Skipping unsupported file type (not a file or directory): {input}");
+            log::warn!("Skipping unsupported file type (not a file or directory): {}", input.display());
         }
     }
 
@@ -80,10 +83,21 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    // ── &[&str] accepted without allocation ──────────────────────────────────
+    // ── &[&str] / &[Path] accepted (generic bound) ───────────────────────────
 
     #[test]
-    fn accepts_str_literals_without_string_allocation() {
+    fn str_slice_with_real_file_is_returned() {
+        // Passes &[&str] directly — the generic bound accepts any AsRef<Path>.
+        let dir = tempdir().expect("temp dir");
+        let file = dir.path().join("book.epub");
+        fs::write(&file, b"").expect("write");
+        let path = file.to_string_lossy().into_owned();
+        let result = collect_files(&[path.as_str()], false);
+        assert_eq!(result, vec![path]);
+    }
+
+    #[test]
+    fn str_slice_with_nonexistent_path_returns_empty() {
         let result = collect_files(&["nonexistent_xyz_path"], false);
         assert!(result.is_empty());
     }


### PR DESCRIPTION
## Summary

- **walker.rs**: `collect_files` is now generic over `S: AsRef<Path>` (upgraded from `AsRef<str>`), accepting \`&[String]\`, \`&[&str]\`, \`&[PathBuf]\`, \`&[&Path]\`, etc. Input is shadowed as \`input.as_ref()\` inside the loop; non-UTF-8 file paths (which cannot be represented as \`String\` in the return value) are warned and skipped, consistent with the existing directory-walk behaviour
- **main.rs**: collects \`Vec<&String>\` from clap instead of cloning to \`Vec<String>\`, eliminating per-element string cloning; a \`Vec\` allocation still occurs as the iterator is lending

## Test plan

- [x] New test \`str_slice_with_real_file_is_returned\`: passes \`&[&str]\` with a real file and asserts the path is returned — exercises the happy path of the generic bound
- [x] New test \`str_slice_with_nonexistent_path_returns_empty\`: passes \`&[&str]\` with a missing path — compile-time proof the bound accepts \`&str\`
- [x] All 42 tests pass (\`cargo nextest run\`)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)