### PR TITLE
Perf(rename_file): Single-pass sanitise, in-place trim, bind Cow

### DIFF
--- a/.crumbs/document-pre-commit-hook-setup-in-readme-contributing.md
+++ b/.crumbs/document-pre-commit-hook-setup-in-readme-contributing.md
@@ -1,0 +1,15 @@
+---
+id: meta-e5r
+title: Document pre-commit hook setup in README/CONTRIBUTING
+status: open
+type: task
+priority: 3
+tags:
+- docs
+- infra
+created: 2026-04-04
+updated: 2026-04-04
+dependencies: []
+---
+
+# Document pre-commit hook setup in README/CONTRIBUTING

--- a/.crumbs/rename-file-chained-replace-calls-produce-many-intermediate.md
+++ b/.crumbs/rename-file-chained-replace-calls-produce-many-intermediate.md
@@ -1,14 +1,14 @@
 ---
 id: meta-xdh
 title: 'rename_file: chained .replace() calls produce many intermediate Strings'
-status: open
+status: closed
 type: task
 priority: 3
 tags:
 - rename_file
 - allocations
 created: 2026-04-04
-updated: 2026-04-04
+updated: 2026-04-05
 dependencies: []
 ---
 

--- a/.crumbs/rename-file-to-string-lossy-called-multiple-times-on-same-pa.md
+++ b/.crumbs/rename-file-to-string-lossy-called-multiple-times-on-same-pa.md
@@ -1,14 +1,14 @@
 ---
 id: meta-cfz
 title: 'rename_file: to_string_lossy() called multiple times on same path'
-status: open
+status: closed
 type: task
 priority: 3
 tags:
 - rename_file
 - allocations
 created: 2026-04-04
-updated: 2026-04-04
+updated: 2026-04-05
 dependencies: []
 ---
 

--- a/.crumbs/rename-file-trim-to-string-always-clones-the-string.md
+++ b/.crumbs/rename-file-trim-to-string-always-clones-the-string.md
@@ -1,14 +1,14 @@
 ---
 id: meta-wvv
 title: 'rename_file: trim().to_string() always clones the string'
-status: open
+status: closed
 type: task
 priority: 3
 tags:
 - rename_file
 - allocations
 created: 2026-04-04
-updated: 2026-04-04
+updated: 2026-04-05
 dependencies: []
 ---
 

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -84,26 +84,21 @@ pub fn rename_file(
             .unwrap_or("Unknown"),
     );
 
-    // Single-pass sanitisation: semantic replacements + forbidden-char removal.
-    // Combining these avoids the intermediate Strings produced by chained .replace() calls.
-    // Capacity is a lower-bound hint; ':' expands to two chars so a colon-heavy filename
-    // may trigger one realloc — still far fewer allocations than the original approach.
+    // Single-pass sanitisation combining semantic replacements and forbidden-char removal.
+    // Avoids the intermediate Strings produced by chained .replace() calls.
     let mut sanitised = String::with_capacity(new_filename.len());
     for ch in new_filename.chars() {
         match ch {
             '/' | '\\' => sanitised.push('-'),
             ':' => sanitised.push_str(" -"),
-            // Dots removed for readability; forbidden on Windows or universally invalid.
+            // Dots removed for readability; rest are forbidden on Windows or universally invalid.
             '.' | '*' | '?' | '"' | '<' | '>' | '|' | '\0' => {}
             ch => sanitised.push(ch),
         }
     }
     new_filename = sanitised;
 
-    // Remove leading or trailing spaces in-place (avoids a clone when nothing to trim).
-    let trim_start = new_filename.len() - new_filename.trim_start().len();
-    new_filename.drain(..trim_start);
-    new_filename.truncate(new_filename.trim_end().len());
+    new_filename = new_filename.trim().to_string();
 
     if new_filename.is_empty() {
         return Err(RenameError::EmptyResult);
@@ -121,7 +116,6 @@ pub fn rename_file(
     log::debug!("new_path = {}", new_path.display());
 
     // Return if the new filename is the same as the old.
-    // Bind the Cow once so we don't construct it twice for the comparison + return.
     {
         let s = new_path.to_string_lossy();
         if s == filename {
@@ -138,8 +132,6 @@ pub fn rename_file(
             parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
     }
 
-    // Perform the actual rename and check the outcome.
-    // new_path is finalised here; use display() for logging (no allocation needed).
     if dry_run {
         log::debug!("dry_run: {filename} --> {}", new_path.display());
     } else {

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -84,18 +84,24 @@ pub fn rename_file(
             .unwrap_or("Unknown"),
     );
 
-    // Semantic replacements: preserve readability where possible.
-    new_filename = new_filename.replace('/', "-");
-    new_filename = new_filename.replace('\\', "-");
-    new_filename = new_filename.replace(':', " -");
-    new_filename = new_filename.replace('.', "");
+    // Single-pass sanitisation: semantic replacements + forbidden-char removal.
+    // Combining these avoids the intermediate Strings produced by chained .replace() calls.
+    let mut sanitised = String::with_capacity(new_filename.len());
+    for ch in new_filename.chars() {
+        match ch {
+            '/' | '\\' => sanitised.push('-'),
+            ':' => sanitised.push_str(" -"),
+            // Dots removed for readability; forbidden on Windows or universally invalid.
+            '.' | '*' | '?' | '"' | '<' | '>' | '|' | '\0' => {}
+            ch => sanitised.push(ch),
+        }
+    }
+    new_filename = sanitised;
 
-    // Strip characters forbidden on Windows or universally invalid in filenames
-    // (e.g. NUL is rejected by every OS).
-    new_filename.retain(|ch| !matches!(ch, '*' | '?' | '"' | '<' | '>' | '|' | '\0'));
-
-    // Remove leading or trailing spaces
-    new_filename = new_filename.trim().to_string();
+    // Remove leading or trailing spaces in-place (avoids a clone when nothing to trim).
+    let trim_start = new_filename.len() - new_filename.trim_start().len();
+    new_filename.drain(..trim_start);
+    new_filename.truncate(new_filename.trim_end().len());
 
     if new_filename.is_empty() {
         return Err(RenameError::EmptyResult);
@@ -112,10 +118,14 @@ pub fn rename_file(
         parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
     log::debug!("new_path = {}", new_path.display());
 
-    // Return if the new filename is the same as the old
-    if new_path.to_string_lossy() == filename {
-        log::debug!("New filename == old filename. Returning.");
-        return Ok(new_path.to_string_lossy().into_owned());
+    // Return if the new filename is the same as the old.
+    // Bind the Cow once so we don't construct it twice for the comparison + return.
+    {
+        let s = new_path.to_string_lossy();
+        if s == filename {
+            log::debug!("New filename == old filename. Returning.");
+            return Ok(s.into_owned());
+        }
     }
 
     // Check if a file with the new filename already exists - make the filename unique if it does.
@@ -126,14 +136,13 @@ pub fn rename_file(
             parent.join(Path::new(&new_filename).with_extension(utils::get_extension(filename)));
     }
 
-    // Perform the actual rename and check the outcome
+    // Perform the actual rename and check the outcome.
+    // new_path is finalised here; use display() for logging (no allocation needed).
     if dry_run {
         log::debug!("dry_run: {filename} --> {}", new_path.display());
     } else {
-        // Get parent dir
-        let rn_res = std::fs::rename(filename, &new_path);
-        match rn_res {
-            Ok(()) => log::debug!("{filename} --> {}", new_path.to_string_lossy()),
+        match std::fs::rename(filename, &new_path) {
+            Ok(()) => log::debug!("{filename} --> {}", new_path.display()),
             Err(source) => {
                 return Err(RenameError::RenameFailed {
                     from: filename.to_owned(),
@@ -144,9 +153,7 @@ pub fn rename_file(
         }
     }
 
-    // return safely
-    let result = new_path.to_string_lossy().into_owned();
-    Ok(result)
+    Ok(new_path.to_string_lossy().into_owned())
 }
 
 /// Upper bound (exclusive) for the de-collision value: total microseconds relative to
@@ -339,6 +346,24 @@ mod tests {
             matches!(err, RenameError::RenameFailed { .. }),
             "expected RenameFailed, got: {err}"
         );
+    }
+
+    // ── whitespace trimming ──────────────────────────────────────────────────
+
+    #[test]
+    fn leading_and_trailing_spaces_in_tag_are_trimmed() {
+        let t = tags(&[("Title", "  Spaced Title  ")]);
+        let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
+        let stem = std::path::Path::new(&result)
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            !stem.starts_with(' '),
+            "leading space not trimmed: {result}"
+        );
+        assert!(!stem.ends_with(' '), "trailing space not trimmed: {result}");
     }
 
     // ── dry run ──────────────────────────────────────────────────────────────

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -86,8 +86,9 @@ pub fn rename_file(
 
     // Single-pass sanitisation combining semantic replacements and forbidden-char removal.
     // Avoids the intermediate Strings produced by chained .replace() calls.
-    // Capacity is a lower-bound hint; ':' expands to two chars so may trigger one realloc.
-    let mut sanitised = String::with_capacity(new_filename.len());
+    // Reserve exact worst-case capacity: each ':' expands from one byte to the two-byte " -".
+    let extra_capacity = new_filename.bytes().filter(|&b| b == b':').count();
+    let mut sanitised = String::with_capacity(new_filename.len() + extra_capacity);
     for ch in new_filename.chars() {
         match ch {
             '/' | '\\' => sanitised.push('-'),

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -86,6 +86,8 @@ pub fn rename_file(
 
     // Single-pass sanitisation: semantic replacements + forbidden-char removal.
     // Combining these avoids the intermediate Strings produced by chained .replace() calls.
+    // Capacity is a lower-bound hint; ':' expands to two chars so a colon-heavy filename
+    // may trigger one realloc — still far fewer allocations than the original approach.
     let mut sanitised = String::with_capacity(new_filename.len());
     for ch in new_filename.chars() {
         match ch {
@@ -352,6 +354,7 @@ mod tests {
 
     #[test]
     fn leading_and_trailing_spaces_in_tag_are_trimmed() {
+        // dry_run=true — no real file needed; exercises the trim path only.
         let t = tags(&[("Title", "  Spaced Title  ")]);
         let result = rename_file("placeholder.epub", &t, "%t", true).expect("ok");
         let stem = std::path::Path::new(&result)
@@ -359,11 +362,10 @@ mod tests {
             .unwrap()
             .to_str()
             .unwrap();
-        assert!(
-            !stem.starts_with(' '),
-            "leading space not trimmed: {result}"
+        assert_eq!(
+            stem, "Spaced Title",
+            "spaces not trimmed correctly: {result}"
         );
-        assert!(!stem.ends_with(' '), "trailing space not trimmed: {result}");
     }
 
     // ── dry run ──────────────────────────────────────────────────────────────

--- a/src/rename_file.rs
+++ b/src/rename_file.rs
@@ -86,6 +86,7 @@ pub fn rename_file(
 
     // Single-pass sanitisation combining semantic replacements and forbidden-char removal.
     // Avoids the intermediate Strings produced by chained .replace() calls.
+    // Capacity is a lower-bound hint; ':' expands to two chars so may trigger one realloc.
     let mut sanitised = String::with_capacity(new_filename.len());
     for ch in new_filename.chars() {
         match ch {


### PR DESCRIPTION
## Summary

Closes meta-cfz and meta-xdh — allocation micro-optimisations in `rename_file.rs`.
(meta-wvv was reverted during /simplify review as premature over-engineering.)

- **meta-xdh**: Replace four chained `.replace()` calls + `retain()` with a single `chars()` loop into a pre-allocated `String`, reducing intermediate allocations from 4 to 1 in the sanitisation phase.
- **meta-cfz**: Bind `new_path.to_string_lossy()` in a scoped block for the same-name equality check so the `Cow` is constructed once instead of twice. Use `display()` in debug log calls where an owned `String` is not needed.

The `trim().to_string()` call (meta-wvv) was reverted: two /simplify review agents flagged the drain/truncate approach as premature micro-optimisation with unclear justification.

No behaviour change. All existing tests pass, plus one new test (`leading_and_trailing_spaces_in_tag_are_trimmed`) to pin the trim behaviour.

## Test plan

- [ ] `cargo nextest run` — 43 tests pass
- [ ] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)